### PR TITLE
Pivoted tables

### DIFF
--- a/Analysis.ipynb
+++ b/Analysis.ipynb
@@ -51,14 +51,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 71,
    "outputs": [],
    "source": [
     "import datetime\n",
     "import glob\n",
     "import os\n",
     "from pathlib import Path\n",
-    "from typing import Callable, Optional, Tuple\n",
+    "from typing import Callable, Optional, Tuple, Any\n",
     "\n",
     "import numpy as np\n",
     "import pandas as pd\n",
@@ -364,7 +364,7 @@
     "    table = find_table(pattern, folder,\n",
     "                       ['request_timestamp_local', 'begintrip_timestamp_local', 'dropoff_timestamp_local', 'status',\n",
     "                        'request_to_begin_distance_miles', 'trip_distance_miles', 'original_fare_local'])\n",
-    "    table = table[table.status.isin(['completed', 'fare_split'])].drop(columns='status')\n",
+    "    table = table[table.status == 'completed'].drop(columns='status')\n",
     "    table.replace({r'\\N': np.nan}, inplace=True)\n",
     "    for col in ['request_to_begin_distance_miles', 'original_fare_local']:\n",
     "        table[col] = table[col].astype(float)\n",
@@ -409,11 +409,12 @@
    "execution_count": 19,
    "outputs": [],
    "source": [
-    "def load_dispatches(path: str | Path) -> Table:\n",
+    "def load_dispatches(folder: Path, pattern: str = 'TODO') -> Table:\n",
     "    # TODO (not finished)\n",
-    "    table = pd.read_csv(path, usecols=['start_timestamp_local', 'end_timestamp_local', 'dispatches', 'completed_trips',\n",
-    "                                       'accepts', 'rejects', 'expireds', 'driver_cancellations', 'rider_cancellations',\n",
-    "                                       'minutes_online', 'minutes_on_trip', 'trip_fares'])\n",
+    "    table = find_table(pattern, folder,\n",
+    "                       ['start_timestamp_local', 'end_timestamp_local', 'dispatches', 'completed_trips',\n",
+    "                        'accepts', 'rejects', 'expireds', 'driver_cancellations', 'rider_cancellations',\n",
+    "                        'minutes_online', 'minutes_on_trip', 'trip_fares'])\n",
     "    return table"
    ],
    "metadata": {
@@ -441,7 +442,7 @@
    "execution_count": 21,
    "outputs": [],
    "source": [
-    "def load_distance_traveled(folder: Path) -> pd.DataFrame:\n",
+    "def load_distance_traveled(folder: Path, pattern: str = 'TODO') -> pd.DataFrame:\n",
     "    pass  # TODO"
    ],
    "metadata": {
@@ -480,7 +481,7 @@
     "    df = find_table('*driver_lifetime_trips*.csv', folder,\n",
     "                    ['Status', 'Local Request Timestamp', 'Begin Trip Local Timestamp', 'Local Dropoff Timestamp',\n",
     "                     'Trip Distance (miles)', 'Duration (Seconds)', 'Local Original Fare'])\n",
-    "    df = df[df['Status'].isin(['completed', 'fare_split'])]\n",
+    "    df = df[df['Status'] == 'completed']\n",
     "    df = time_tuples_to_periods(df, columns=['Local Request Timestamp', 'Begin Trip Local Timestamp',\n",
     "                                             'Local Dropoff Timestamp'],\n",
     "                                extra_info=[lambda r: {'status': 'P2'},\n",
@@ -504,26 +505,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 126,
    "outputs": [],
    "source": [
     "def guillaume_filtering_logic(\n",
     "        daily: Table,\n",
     "        percentage_df_path: Optional[str | Path] = data_folder / 'Guillaume' / 'percentage.csv'\n",
     ") -> Table:\n",
+    "    # TODO fix, not working anymore\n",
     "    # First, weight P1 times based on the percentage that Guillaume was working for Uber on that month\n",
     "    percentage = pd.read_csv(percentage_df_path)\n",
     "    percentage['Uber'] /= 100\n",
-    "    P1 = daily.loc[daily.status.str.contains('P1')].copy()\n",
-    "    for i, row in percentage.iterrows():\n",
-    "        if row['Uber'] == 0 and P1[(P1.date.dt.year == row.year) & (\n",
-    "                P1.date.dt.month == row.month)].duration.sum() > datetime.timedelta(0):\n",
-    "            print(\n",
-    "                f'bad specification for {row.year}/{row.month}: activity found even though specified percentage was 0')\n",
-    "        P1['duration'] = np.where(\n",
-    "            (P1.date.dt.year == row.year) & (P1.date.dt.month == row.month),\n",
-    "            P1['duration'] * row['Uber'],\n",
-    "            P1['duration'])\n",
+    "    daily['datetime'] = pd.to_datetime(daily['date'])\n",
+    "    duration_P1_cols = list(filter(lambda c: 'duration_P1' in c and 'AM' in c and 'weekday' in c, daily.columns))\n",
+    "    new_cols = []\n",
+    "    for c in duration_P1_cols:\n",
+    "        for i, row in percentage.iterrows():\n",
+    "            daily[f'{c}(filtered)'] = np.where(\n",
+    "                (daily.datetime.dt.year == row.year) & (daily.datetime.dt.month == row.month),\n",
+    "                daily[c] * row['Uber'], daily[c])\n",
+    "        new_cols.append(f'{c}(filtered)')\n",
     "    # Second, remove all morning weekday entries when Guillaume was working for IMAD, except for the specific dates below\n",
     "    dates_to_keep = [datetime.date(2020, 11, 26),\n",
     "                     *pd.date_range(datetime.date(2020, 12, 21), datetime.date(2020, 12, 25)).values,\n",
@@ -532,11 +533,8 @@
     "                     *pd.date_range(datetime.date(2021, 9, 20), datetime.date(2021, 10, 3)).values,\n",
     "                     *pd.date_range(datetime.date(2021, 11, 25), datetime.date(2021, 12, 12)).values,\n",
     "                     *pd.date_range(datetime.date(2022, 4, 25), datetime.date(2022, 5, 13)).values]\n",
-    "    P1.drop(P1[(P1.time_of_day == 'AM') &\n",
-    "               (P1.day_type == 'week day') &\n",
-    "               ~P1.date.apply(lambda d: d.date()).isin(dates_to_keep)].index,\n",
-    "            inplace=True)\n",
-    "    return P1"
+    "    daily.loc[daily[~daily.datetime.apply(lambda d: d.date()).isin(dates_to_keep)].index, new_cols] = 0\n",
+    "    return daily[new_cols]"
    ],
    "metadata": {
     "collapsed": false
@@ -562,11 +560,10 @@
     "                **{k: v * (end - begin) / og_duration if isinstance(v, float) else v for k, v in attributes.items()}}\n",
     "\n",
     "    def rec(begin: Timestamp, end: Timestamp, **rest) -> list[dict]:\n",
-    "        rows = []\n",
     "        og_duration = end - begin\n",
     "        # Check if the interval spans many days, and split into as many days as it spans\n",
     "        if begin.day != end.day:\n",
-    "            rows.append(scaled_interval(begin, begin.replace(hour=23, minute=59, second=59), rest, og_duration))\n",
+    "            rows = [scaled_interval(begin, begin.replace(hour=23, minute=59, second=59), rest, og_duration)]\n",
     "            for days in range(end.day - begin.day - 1):\n",
     "                mid = begin + datetime.timedelta(days=days)\n",
     "                rows.append(scaled_interval(mid.replace(hour=0, minute=0, second=0),\n",
@@ -576,9 +573,8 @@
     "            return [e for r in rows for e in rec(**r)]\n",
     "        # Check if the interval spans many AM/PM periods\n",
     "        elif begin.hour < 12 <= end.hour:\n",
-    "            rows.append(scaled_interval(begin, end.replace(hour=11, minute=59, second=59), rest, og_duration))\n",
-    "            rows.append(scaled_interval(end.replace(hour=12, minute=0, second=0), end, rest, og_duration))\n",
-    "            return rows\n",
+    "            return [scaled_interval(begin, end.replace(hour=11, minute=59, second=59), rest, og_duration),\n",
+    "                    scaled_interval(end.replace(hour=12, minute=0, second=0), end, rest, og_duration)]\n",
     "        else:\n",
     "            return [{'begin': begin, 'end': end, **rest}]\n",
     "\n",
@@ -593,10 +589,64 @@
    "execution_count": 26,
    "outputs": [],
    "source": [
+    "def split_hours(table: PeriodTable) -> PeriodTable:\n",
+    "    \"\"\"\n",
+    "    Splits intervals spanning many hours periods in as many intervals as hours covered by the interval.\n",
+    "    If the interval is associated to numerical values (like distance or money), these values are\n",
+    "    transferred to the new intervals but are weighted according to the new intervals' duration.\n",
+    "    :param table: the table whose intervals should be split\n",
+    "    :return: a table with no intervals spanning over AM and PM\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def scaled_interval(begin: Timestamp, end: Timestamp, attributes: dict, og_duration) -> dict:\n",
+    "        \"\"\"Creates an interval (a dict with begin, end and other attributes) given the original attributes and the original \"\"\"\n",
+    "        return {'begin': begin, 'end': end,\n",
+    "                **{k: v * (end - begin) / og_duration if isinstance(v, float) else v for k, v in attributes.items()}}\n",
+    "\n",
+    "    def rec(begin: Timestamp, end: Timestamp, **rest) -> list[dict]:\n",
+    "        og_duration = end - begin\n",
+    "        # Check if the interval spans many days, and split into as many days as it spans\n",
+    "        if begin.hour != end.hour:\n",
+    "            rows = [scaled_interval(begin, begin.replace(minute=59, second=59), rest, og_duration)]\n",
+    "            for hours in range(end.hour - begin.hour - 1):\n",
+    "                mid = begin + datetime.timedelta(hours=hours)\n",
+    "                rows.append(scaled_interval(mid.replace(minute=0, second=0),\n",
+    "                                            mid.replace(minute=59, second=59), rest, og_duration))\n",
+    "            rows.append(scaled_interval(end.replace(minute=0, second=0), end, rest, og_duration))\n",
+    "            return rows\n",
+    "        return [{'begin': begin, 'end': end, **rest}]\n",
+    "\n",
+    "    return pd.DataFrame([e for d in table.to_dict('records') for e in rec(**d)])"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "outputs": [],
+   "source": [
     "def find_week_limits(date: Timestamp) -> str:\n",
     "    week_start = date - datetime.timedelta(days=date.weekday())\n",
     "    week_end = week_start + datetime.timedelta(days=6)\n",
     "    return f'{week_start.date()} to {week_end.date()}'.replace('-', '/').replace('to', '-')"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "outputs": [],
+   "source": [
+    "def select(d: dict[str], keep: Optional[list[str]] = None, drop: Optional[list[str]] = None) -> dict[str]:\n",
+    "    assert (keep is None) != (drop is None), 'Only one of keep or drop can be specified'\n",
+    "    if keep is not None:\n",
+    "        return {k: v for k, v in d.items() if k in keep}\n",
+    "    if drop is not None:\n",
+    "        return {k: v for k, v in d.items() if k not in drop}"
    ],
    "metadata": {
     "collapsed": false
@@ -613,63 +663,93 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 120,
+   "outputs": [],
+   "source": [
+    "all_facets = ['duration_h', 'distance_km', 'uber_paid']\n",
+    "all_time_properties = {'day_of_week': lambda d: d.day_name(),\n",
+    "                       'day_type': lambda d: 'weekday' if d.weekday() < 5 else 'weekend',\n",
+    "                       'time_of_day': lambda d: 'AM' if d.hour < 12 else 'PM',\n",
+    "                       'night': lambda d: 'night' if d.hour <= 6 or 23 < d.hour else 'day'}"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
    "outputs": [],
    "source": [
     "def pipeline(\n",
-    "        table: PeriodTable,\n",
+    "        periods: PeriodTable,\n",
     "        interval_logic: Optional[Callable[[PeriodTable], PeriodTable]] = None,\n",
-    "        splitting_logic: Optional[Callable[[PeriodTable], PeriodTable]] = None,\n",
     "        filtering_logic: Optional[Callable[[PeriodTable], PeriodTable]] = None,\n",
+    "        time_properties: Optional[dict[str, Callable[[Timestamp], Any]]] = None,\n",
     "        name: str = 'analysis',\n",
-    "        facets: Tuple[str, ...] = ('duration', 'distance_km', 'uber_paid'),\n",
-    "        save_at: Path = data_folder / 'results'\n",
+    "        facets: list[str] = all_facets,\n",
+    "        save_at: Path = data_folder / 'results',\n",
     ") -> Tuple[pd.DataFrame, ...]:\n",
     "    # Apply interval logic if specified\n",
     "    if interval_logic is not None:\n",
-    "        table = interval_logic(table)\n",
+    "        periods = interval_logic(periods)\n",
     "\n",
-    "    # Make sure that each interval is contained within a single 12-hour time period (AM or PM) by splitting when necessary\n",
-    "    # Note: this logic is specific to each driver\n",
-    "    if splitting_logic is not None:\n",
-    "        table = splitting_logic(table)\n",
+    "    # Compute the duration of a period once, in the beginning\n",
+    "    periods['duration_h'] = (periods.end - periods.begin) / datetime.timedelta(hours=1)\n",
+    "    # Split intervals spanning many hours\n",
+    "    periods = split_hours(periods)\n",
     "\n",
-    "    # Now we can compute all of these time properties since they will be the same for begin and end\n",
-    "    table['date'] = table.end.dt.date\n",
-    "    table['day_of_week'] = table.end.dt.day_name()\n",
-    "    table['day_type'] = (table.end.dt.weekday < 5).replace({True: 'week day', False: 'weekend'})\n",
-    "    table['time_of_day'] = (table.end.dt.hour < 12).replace({True: 'AM', False: 'PM'})\n",
-    "    table['week'] = table.end.apply(find_week_limits)\n",
-    "    table['month'] = table.end.apply(lambda d: f'{d.month:02d}. {d.month_name()}')\n",
-    "    table['year'] = table.end.dt.year\n",
-    "    table['duration'] = table.end - table.begin\n",
+    "    counts = periods[['begin', 'end']].value_counts()\n",
+    "    duplicates = counts[counts > 1].reset_index()\n",
+    "    display(periods[periods.begin.isin(duplicates.begin) & periods.end.isin(duplicates.end)])\n",
     "\n",
-    "    # Group entries by day and time period\n",
-    "    daily = table.groupby(['date', 'year', 'month', 'week', 'day_of_week',\n",
-    "                           'day_type', 'time_of_day', 'status']).agg({f: 'sum' for f in facets}).reset_index()\n",
-    "    daily['date'] = pd.to_datetime(daily.date)\n",
+    "    # Pivot table so that each there is a single line per interval and per granularity of interest\n",
+    "    periods = periods.pivot(index=['begin', 'end'], columns=['status'], values=facets).reset_index()\n",
+    "    periods[periods == 0] = np.nan\n",
+    "    periods.drop(columns=periods.columns[periods.isna().all()], inplace=True)  # this and previous remove columns that have only 0/nans\n",
+    "    # Merges column multiindex into a single index by joining the levels\n",
+    "    periods.columns = periods.columns.map(lambda t: '.'.join(t) if t[1] else t[0])\n",
+    "\n",
+    "    agg_dict = {c: 'sum' for c in periods.columns if any(f in c for f in facets)}\n",
+    "\n",
+    "    date_info = list(time_properties.keys()) if time_properties is not None else []\n",
+    "\n",
+    "    # Compute these datetime properties since they will be the same for begin and end (thanks to split_hours)\n",
+    "    if time_properties is not None:\n",
+    "        for k, f in time_properties.items():\n",
+    "            periods[k] = periods.end.apply(f)\n",
+    "        periods = periods.pivot(index=['begin', 'end'], columns=date_info, values=list(agg_dict.keys())).reset_index()\n",
+    "        periods.columns = periods.columns.map(lambda t: '.'.join(t) if t[1] else t[0])\n",
+    "        agg_dict = {c: 'sum' for c in periods.columns if any(f in c for f in facets)}\n",
+    "    periods['hour'] = periods.end.apply(lambda d: f'{d.hour}-{(d + datetime.timedelta(hours=1)).hour}')\n",
+    "    periods['date'] = periods.end.dt.date\n",
+    "    periods['week'] = periods.end.apply(find_week_limits)\n",
+    "    periods['month'] = periods.end.apply(lambda d: f'{d.month:02d}. {d.month_name()}')\n",
+    "    periods['year'] = periods.end.dt.year\n",
+    "\n",
+    "    hourly = periods.groupby(['date', 'hour']).agg(agg_dict).reset_index()\n",
+    "    daily = periods.groupby(['date']).agg(agg_dict).reset_index()\n",
     "\n",
     "    # Filter the data if a filtering function is specified\n",
     "    if filtering_logic is not None:\n",
-    "        filtered = filtering_logic(daily)\n",
-    "        filtered['status'] = filtered.status + '|filtered'\n",
-    "        daily = pd.concat([daily, filtered])\n",
+    "        daily = pd.concat([daily, filtering_logic(daily)], axis=1)\n",
     "\n",
-    "    monthly = daily.groupby(['year', 'month', 'status']).agg({f: 'sum' for f in facets}).reset_index()\n",
-    "    weekly = daily.groupby(['week', 'status']).agg({f: 'sum' for f in facets}).reset_index()\n",
-    "    yearly = daily.groupby(['year', 'status']).agg({f: 'sum' for f in facets}).reset_index()\n",
-    "    total = yearly.groupby(['status']).agg({f: 'sum' for f in facets}).reset_index()\n",
+    "    weekly = periods.groupby(['week']).agg(agg_dict).reset_index()\n",
+    "    monthly = periods.groupby(['year', 'month']).agg(agg_dict).reset_index()\n",
+    "    yearly = periods.groupby(['year']).agg(agg_dict).reset_index()\n",
+    "    total = yearly.agg(agg_dict).to_frame().T\n",
     "\n",
     "    # Writing tables to disk\n",
     "    save_at.mkdir(parents=True, exist_ok=True)\n",
-    "    table.to_csv(save_at / f'{name}_original_splitted.csv', index=False)\n",
-    "    daily.to_csv(save_at / f'{name}_daily.csv', index=False)\n",
-    "    weekly.to_csv(save_at / f'{name}_weekly.csv', index=False)\n",
-    "    monthly.to_csv(save_at / f'{name}_monthly.csv', index=False)\n",
-    "    yearly.to_csv(save_at / f'{name}_yearly.csv', index=False)\n",
-    "    total.to_csv(save_at / f'{name}_total.csv', index=False)\n",
+    "    periods.to_csv(save_at / f'0_{name}_periods.csv', index=False, float_format='%.3f')\n",
+    "    hourly.to_csv(save_at / f'1_{name}_hourly.csv', index=False, float_format='%.3f')\n",
+    "    daily.to_csv(save_at / f'2_{name}_daily.csv', index=False, float_format='%.3f')\n",
+    "    weekly.to_csv(save_at / f'3_{name}_weekly.csv', index=False, float_format='%.3f')\n",
+    "    monthly.to_csv(save_at / f'4_{name}_monthly.csv', index=False, float_format='%.3f')\n",
+    "    yearly.to_csv(save_at / f'5_{name}_yearly.csv', index=False, float_format='%.3f')\n",
+    "    total.to_csv(save_at / f'6_{name}_total.csv', index=False, float_format='%.3f')\n",
     "\n",
-    "    return daily, weekly, yearly, total"
+    "    return hourly, daily, weekly, yearly, total"
    ],
    "metadata": {
     "collapsed": false
@@ -688,14 +768,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 129,
    "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Guillaume' / 'raw' / 'SAR (new)'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
-    "             splitting_logic=split_AM_PM,\n",
     "             filtering_logic=guillaume_filtering_logic,\n",
-    "             name='sar',\n",
+    "             name='sar', time_properties=select(all_time_properties, keep=['time_of_day']),\n",
     "             save_at=data_folder / 'Guillaume' / 'results')"
    ],
    "metadata": {
@@ -704,12 +783,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 130,
    "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Kidane' / 'raw' / 'SAR'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
-    "             name='sar',\n",
+    "             name='sar', time_properties=all_time_properties,\n",
     "             save_at=data_folder / 'Kidane' / 'results')"
    ],
    "metadata": {
@@ -718,12 +797,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "outputs": [],
+   "execution_count": 139,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "                          begin                       end status  uber_paid  \\\n54915 2021-08-29 18:00:00+00:00 2021-08-29 18:00:38+00:00     P2   0.000000   \n54957 2021-08-31 11:00:00+00:00 2021-08-31 11:04:43+00:00     P2   0.000000   \n55026 2021-09-02 17:00:00+00:00 2021-09-02 17:02:45+00:00     P2   0.000000   \n55081 2021-09-06 16:00:00+00:00 2021-09-06 16:00:04+00:00     P2   0.000000   \n55195 2021-09-11 21:00:00+00:00 2021-09-11 21:00:09+00:00     P2   0.000000   \n73247 2021-08-29 18:00:00+00:00 2021-08-29 18:00:38+00:00     P3   1.231030   \n73274 2021-08-31 11:00:00+00:00 2021-08-31 11:04:43+00:00     P3   4.823799   \n73323 2021-09-02 17:00:00+00:00 2021-09-02 17:02:45+00:00     P3   8.644030   \n73359 2021-09-06 16:00:00+00:00 2021-09-06 16:00:04+00:00     P3   0.158475   \n73426 2021-09-11 21:00:00+00:00 2021-09-11 21:00:09+00:00     P3   0.338265   \n78214 2022-10-30 02:48:01+00:00 2022-10-30 02:01:47+00:00     P3  46.100000   \n78215 2022-10-30 02:48:01+00:00 2022-10-30 02:01:47+00:00     P3   0.000000   \n\n       distance_km  duration_h  \n54915     0.000000    0.010556  \n54957     0.000000    0.078611  \n55026     0.003945    0.045833  \n55081     0.000000    0.001111  \n55195     0.000000    0.002500  \n73247     0.248395    0.010556  \n73274     1.065423    0.078611  \n73323     1.113123    0.045833  \n73359     0.022923    0.001111  \n73426     0.056242    0.002500  \n78214     6.515524   -0.770556  \n78215     0.000000   -0.770556  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>begin</th>\n      <th>end</th>\n      <th>status</th>\n      <th>uber_paid</th>\n      <th>distance_km</th>\n      <th>duration_h</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>54915</th>\n      <td>2021-08-29 18:00:00+00:00</td>\n      <td>2021-08-29 18:00:38+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.010556</td>\n    </tr>\n    <tr>\n      <th>54957</th>\n      <td>2021-08-31 11:00:00+00:00</td>\n      <td>2021-08-31 11:04:43+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.078611</td>\n    </tr>\n    <tr>\n      <th>55026</th>\n      <td>2021-09-02 17:00:00+00:00</td>\n      <td>2021-09-02 17:02:45+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.003945</td>\n      <td>0.045833</td>\n    </tr>\n    <tr>\n      <th>55081</th>\n      <td>2021-09-06 16:00:00+00:00</td>\n      <td>2021-09-06 16:00:04+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.001111</td>\n    </tr>\n    <tr>\n      <th>55195</th>\n      <td>2021-09-11 21:00:00+00:00</td>\n      <td>2021-09-11 21:00:09+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.002500</td>\n    </tr>\n    <tr>\n      <th>73247</th>\n      <td>2021-08-29 18:00:00+00:00</td>\n      <td>2021-08-29 18:00:38+00:00</td>\n      <td>P3</td>\n      <td>1.231030</td>\n      <td>0.248395</td>\n      <td>0.010556</td>\n    </tr>\n    <tr>\n      <th>73274</th>\n      <td>2021-08-31 11:00:00+00:00</td>\n      <td>2021-08-31 11:04:43+00:00</td>\n      <td>P3</td>\n      <td>4.823799</td>\n      <td>1.065423</td>\n      <td>0.078611</td>\n    </tr>\n    <tr>\n      <th>73323</th>\n      <td>2021-09-02 17:00:00+00:00</td>\n      <td>2021-09-02 17:02:45+00:00</td>\n      <td>P3</td>\n      <td>8.644030</td>\n      <td>1.113123</td>\n      <td>0.045833</td>\n    </tr>\n    <tr>\n      <th>73359</th>\n      <td>2021-09-06 16:00:00+00:00</td>\n      <td>2021-09-06 16:00:04+00:00</td>\n      <td>P3</td>\n      <td>0.158475</td>\n      <td>0.022923</td>\n      <td>0.001111</td>\n    </tr>\n    <tr>\n      <th>73426</th>\n      <td>2021-09-11 21:00:00+00:00</td>\n      <td>2021-09-11 21:00:09+00:00</td>\n      <td>P3</td>\n      <td>0.338265</td>\n      <td>0.056242</td>\n      <td>0.002500</td>\n    </tr>\n    <tr>\n      <th>78214</th>\n      <td>2022-10-30 02:48:01+00:00</td>\n      <td>2022-10-30 02:01:47+00:00</td>\n      <td>P3</td>\n      <td>46.100000</td>\n      <td>6.515524</td>\n      <td>-0.770556</td>\n    </tr>\n    <tr>\n      <th>78215</th>\n      <td>2022-10-30 02:48:01+00:00</td>\n      <td>2022-10-30 02:01:47+00:00</td>\n      <td>P3</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>-0.770556</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Index contains duplicate entries, cannot reshape",
+     "output_type": "error",
+     "traceback": [
+      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
+      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
+      "Input \u001B[0;32mIn [139]\u001B[0m, in \u001B[0;36m<cell line: 1>\u001B[0;34m()\u001B[0m\n\u001B[0;32m----> 1\u001B[0m _ \u001B[38;5;241m=\u001B[39m \u001B[43mpipeline\u001B[49m\u001B[43m(\u001B[49m\u001B[43mload_sar\u001B[49m\u001B[43m(\u001B[49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mraw\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mSAR\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      2\u001B[0m \u001B[43m             \u001B[49m\u001B[43minterval_logic\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;28;43;01mlambda\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mt\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[43mmerge_overlapping_intervals\u001B[49m\u001B[43m(\u001B[49m\u001B[43mt\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43m{\u001B[49m\u001B[43mc\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msum\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;28;43;01mfor\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mc\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;129;43;01min\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43muber_paid\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mdistance_km\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m}\u001B[49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      3\u001B[0m \u001B[43m             \u001B[49m\u001B[43mname\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msar\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mtime_properties\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mall_time_properties\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m             \u001B[49m\u001B[43msave_at\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mresults\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\n",
+      "Input \u001B[0;32mIn [138]\u001B[0m, in \u001B[0;36mpipeline\u001B[0;34m(periods, interval_logic, filtering_logic, time_properties, name, facets, save_at)\u001B[0m\n\u001B[1;32m     21\u001B[0m display(periods[periods\u001B[38;5;241m.\u001B[39mbegin\u001B[38;5;241m.\u001B[39misin(duplicates\u001B[38;5;241m.\u001B[39mbegin) \u001B[38;5;241m&\u001B[39m periods\u001B[38;5;241m.\u001B[39mend\u001B[38;5;241m.\u001B[39misin(duplicates\u001B[38;5;241m.\u001B[39mend)])\n\u001B[1;32m     23\u001B[0m \u001B[38;5;66;03m# Pivot table so that each there is a single line per interval and per granularity of interest\u001B[39;00m\n\u001B[0;32m---> 24\u001B[0m periods \u001B[38;5;241m=\u001B[39m \u001B[43mperiods\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mbegin\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mend\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mstatus\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfacets\u001B[49m\u001B[43m)\u001B[49m\u001B[38;5;241m.\u001B[39mreset_index()\n\u001B[1;32m     25\u001B[0m periods[periods \u001B[38;5;241m==\u001B[39m \u001B[38;5;241m0\u001B[39m] \u001B[38;5;241m=\u001B[39m np\u001B[38;5;241m.\u001B[39mnan\n\u001B[1;32m     26\u001B[0m periods\u001B[38;5;241m.\u001B[39mdrop(columns\u001B[38;5;241m=\u001B[39mperiods\u001B[38;5;241m.\u001B[39mcolumns[periods\u001B[38;5;241m.\u001B[39misna()\u001B[38;5;241m.\u001B[39mall()], inplace\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mTrue\u001B[39;00m)  \u001B[38;5;66;03m# this and previous remove columns that have only 0/nans\u001B[39;00m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/frame.py:7885\u001B[0m, in \u001B[0;36mDataFrame.pivot\u001B[0;34m(self, index, columns, values)\u001B[0m\n\u001B[1;32m   7880\u001B[0m \u001B[38;5;129m@Substitution\u001B[39m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m   7881\u001B[0m \u001B[38;5;129m@Appender\u001B[39m(_shared_docs[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpivot\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   7882\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mpivot\u001B[39m(\u001B[38;5;28mself\u001B[39m, index\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, columns\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, values\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m DataFrame:\n\u001B[1;32m   7883\u001B[0m     \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mpivot\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m pivot\n\u001B[0;32m-> 7885\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mcolumns\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mvalues\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/pivot.py:520\u001B[0m, in \u001B[0;36mpivot\u001B[0;34m(data, index, columns, values)\u001B[0m\n\u001B[1;32m    518\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    519\u001B[0m         indexed \u001B[38;5;241m=\u001B[39m data\u001B[38;5;241m.\u001B[39m_constructor_sliced(data[values]\u001B[38;5;241m.\u001B[39m_values, index\u001B[38;5;241m=\u001B[39mmultiindex)\n\u001B[0;32m--> 520\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mindexed\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[43mcolumns_listlike\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/frame.py:8428\u001B[0m, in \u001B[0;36mDataFrame.unstack\u001B[0;34m(self, level, fill_value)\u001B[0m\n\u001B[1;32m   8366\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   8367\u001B[0m \u001B[38;5;124;03mPivot a level of the (necessarily hierarchical) index labels.\u001B[39;00m\n\u001B[1;32m   8368\u001B[0m \n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m   8424\u001B[0m \u001B[38;5;124;03mdtype: float64\u001B[39;00m\n\u001B[1;32m   8425\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   8426\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m unstack\n\u001B[0;32m-> 8428\u001B[0m result \u001B[38;5;241m=\u001B[39m \u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m   8430\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m result\u001B[38;5;241m.\u001B[39m__finalize__(\u001B[38;5;28mself\u001B[39m, method\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124munstack\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:478\u001B[0m, in \u001B[0;36munstack\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    476\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj, DataFrame):\n\u001B[1;32m    477\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex):\n\u001B[0;32m--> 478\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43m_unstack_frame\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    479\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    480\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39mT\u001B[38;5;241m.\u001B[39mstack(dropna\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m)\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:505\u001B[0m, in \u001B[0;36m_unstack_frame\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    503\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39m_constructor(mgr)\n\u001B[1;32m    504\u001B[0m \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[0;32m--> 505\u001B[0m     unstacker \u001B[38;5;241m=\u001B[39m \u001B[43m_Unstacker\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mconstructor\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_constructor\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    506\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m unstacker\u001B[38;5;241m.\u001B[39mget_result(\n\u001B[1;32m    507\u001B[0m         obj\u001B[38;5;241m.\u001B[39m_values, value_columns\u001B[38;5;241m=\u001B[39mobj\u001B[38;5;241m.\u001B[39mcolumns, fill_value\u001B[38;5;241m=\u001B[39mfill_value\n\u001B[1;32m    508\u001B[0m     )\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:140\u001B[0m, in \u001B[0;36m_Unstacker.__init__\u001B[0;34m(self, index, level, constructor)\u001B[0m\n\u001B[1;32m    133\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m num_cells \u001B[38;5;241m>\u001B[39m np\u001B[38;5;241m.\u001B[39miinfo(np\u001B[38;5;241m.\u001B[39mint32)\u001B[38;5;241m.\u001B[39mmax:\n\u001B[1;32m    134\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    135\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mThe following operation may generate \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mnum_cells\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m cells \u001B[39m\u001B[38;5;124m\"\u001B[39m\n\u001B[1;32m    136\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124min the resulting pandas object.\u001B[39m\u001B[38;5;124m\"\u001B[39m,\n\u001B[1;32m    137\u001B[0m         PerformanceWarning,\n\u001B[1;32m    138\u001B[0m     )\n\u001B[0;32m--> 140\u001B[0m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_make_selectors\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:192\u001B[0m, in \u001B[0;36m_Unstacker._make_selectors\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    189\u001B[0m mask\u001B[38;5;241m.\u001B[39mput(selector, \u001B[38;5;28;01mTrue\u001B[39;00m)\n\u001B[1;32m    191\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m mask\u001B[38;5;241m.\u001B[39msum() \u001B[38;5;241m<\u001B[39m \u001B[38;5;28mlen\u001B[39m(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mindex):\n\u001B[0;32m--> 192\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mIndex contains duplicate entries, cannot reshape\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    194\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mgroup_index \u001B[38;5;241m=\u001B[39m comp_index\n\u001B[1;32m    195\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mmask \u001B[38;5;241m=\u001B[39m mask\n",
+      "\u001B[0;31mValueError\u001B[0m: Index contains duplicate entries, cannot reshape"
+     ]
+    }
+   ],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Brice' / 'raw' / 'SAR'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
-    "             name='sar',\n",
+    "             name='sar', time_properties=all_time_properties,\n",
     "             save_at=data_folder / 'Brice' / 'results')"
    ],
    "metadata": {
@@ -741,12 +848,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 132,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Guillaume' / 'raw' / 'Portal' / 'Driver'),\n",
-    "             name='portal',\n",
-    "             splitting_logic=split_AM_PM,\n",
+    "             name='portal', time_properties=all_time_properties,\n",
     "             filtering_logic=guillaume_filtering_logic,\n",
     "             save_at=data_folder / 'Guillaume' / 'results')"
    ],
@@ -756,12 +862,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 133,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Aria' / 'raw' / 'Portal' / 'Driver'),\n",
-    "             name='portal',\n",
-    "             splitting_logic=split_AM_PM,\n",
+    "             name='portal', time_properties=select(all_time_properties, keep=['night', 'day_type']),\n",
     "             save_at=data_folder / 'Aria' / 'results')"
    ],
    "metadata": {
@@ -770,7 +875,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "outputs": [],
    "source": [],
    "metadata": {

--- a/Analysis.ipynb
+++ b/Analysis.ipynb
@@ -32,13 +32,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Requirement already satisfied: numpy in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (1.23.3)\r\n",
-      "Requirement already satisfied: pandas in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (1.4.4)\r\n",
-      "Requirement already satisfied: portion in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (2.3.0)\r\n",
-      "Requirement already satisfied: python-dateutil>=2.8.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (from pandas) (2.8.2)\r\n",
-      "Requirement already satisfied: pytz>=2020.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (from pandas) (2022.1)\r\n",
-      "Requirement already satisfied: sortedcontainers~=2.2 in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (from portion) (2.4.0)\r\n",
-      "Requirement already satisfied: six>=1.5 in /home/lstreit/anaconda3/envs/hestia/lib/python3.10/site-packages (from python-dateutil>=2.8.1->pandas) (1.16.0)\r\n"
+      "Requirement already satisfied: numpy in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (1.23.5)\r\n",
+      "Requirement already satisfied: pandas in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (1.5.2)\r\n",
+      "Requirement already satisfied: portion in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (2.3.0)\r\n",
+      "Requirement already satisfied: python-dateutil>=2.8.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from pandas) (2.8.2)\r\n",
+      "Requirement already satisfied: pytz>=2020.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from pandas) (2022.6)\r\n",
+      "Requirement already satisfied: sortedcontainers~=2.2 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from portion) (2.4.0)\r\n",
+      "Requirement already satisfied: six>=1.5 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from python-dateutil>=2.8.1->pandas) (1.16.0)\r\n"
      ]
     }
    ],
@@ -51,7 +51,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 2,
    "outputs": [],
    "source": [
     "import datetime\n",
@@ -61,8 +61,7 @@
     "from typing import Callable, Optional, Tuple, Any\n",
     "\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
-    "import portion as P"
+    "import pandas as pd"
    ],
    "metadata": {
     "collapsed": false
@@ -151,8 +150,8 @@
     "    If found, reads it and assigns the file name as a column.\n",
     "    :param pattern: a glob file pattern\n",
     "    :param folder: a path leading to a folder where the pattern should be applied\n",
-    "    :param usecols: an optional list of columns in the\n",
-    "    :return: a Table (a.k.a. pandas DataFrame) having the specified columns and the file name as a column\n",
+    "    :param usecols: an optional list of columns present in the data file, only they will be loaded\n",
+    "    :return: a Table (a.k.a. pandas DataFrame) having the specified columns and the file name as a column.\n",
     "    \"\"\"\n",
     "    file = find_file(pattern, folder)\n",
     "    table = pd.read_csv(file, usecols=usecols)\n",
@@ -175,7 +174,7 @@
     "    :param pattern: a glob file pattern\n",
     "    :param folder: a path leading to a folder where the pattern should be applied\n",
     "    :param date_cols: a list of column names that are dates\n",
-    "    :return: the minimum and maxixmum observed dates\n",
+    "    :return: the minimum and maximum observed dates\n",
     "    Usage:\n",
     "    find_date_range('*Driver Trip Status.csv', data_folder / 'Brice' / 'raw' / 'SAR',\n",
     "                    ['begin_timestamp_local', 'end_timestamp_local'])\n",
@@ -190,10 +189,10 @@
    }
   },
   {
-   "cell_type": "code",
-   "execution_count": 10,
-   "outputs": [],
+   "cell_type": "markdown",
    "source": [
+    "Currently unused code\n",
+    "\n",
     "def df_to_interval(df: PeriodTable) -> P.interval:\n",
     "    \"\"\"Converts a DataFrame with columns 'begin' and 'end' into a Portion interval, merging entries that overlap.\"\"\"\n",
     "    return P.Interval(*[P.closed(row['begin'], row['end']) for row in df.to_dict('records')])\n",
@@ -201,7 +200,29 @@
     "\n",
     "def interval_to_df(interval: P.interval) -> PeriodTable:\n",
     "    \"\"\"Converts a Portion interval into a dataframe with columns 'begin' and 'end'.\"\"\"\n",
-    "    return pd.DataFrame([{'begin': begin, 'end': end} for _, begin, end, _ in P.to_data(interval)])"
+    "    return pd.DataFrame([{'begin': begin, 'end': end} for _, begin, end, _ in P.to_data(interval)])\n",
+    "\n",
+    "def make_status_intervals(df: PeriodTable) -> dict[str, P.interval]:\n",
+    "    return {s: df_to_interval(df[df.status == s]) for s in df.status.unique()}\n",
+    "\n",
+    "def interval_merge_logic(lt: dict[str, P.interval], oo: dict[str, P.interval]) -> dict[str, P.interval]:\n",
+    "    P3 = lt['P3'] | oo['P3']\n",
+    "    P2 = (lt['P2'] | oo['P2']) - P3\n",
+    "    P1 = oo['P1'] - (P2 | P3)\n",
+    "    return {'P1': P1, 'P2': P2, 'P3': P3}\n",
+    "\n",
+    "def main_interval_logic(lt: dict[str, P.interval], oo: dict[str, P.interval], P0_has_priority=False) -> Table:\n",
+    "    \"\"\"Consider the following ordering of priorities: P3 > P2 > P1. P0_has_priority determines if P0 is on the left or right of inequalities.\"\"\"\n",
+    "    if P0_has_priority:\n",
+    "        for d in [lt, oo]:\n",
+    "            for k in d.keys():\n",
+    "                if k != 'P0':\n",
+    "                    d[k] = d[k] - oo['P0']\n",
+    "    lt['P2'] = lt['P2'] - lt['P3']\n",
+    "    oo['P2'] = oo['P2'] - oo['P3']\n",
+    "    oo['P1'] = oo['P1'] - (oo['P2'] | oo['P3'])\n",
+    "    intervals = interval_merge_logic(lt, oo)\n",
+    "    return pd.concat([interval_to_df(i).assign(status=f'{s} consistent') for s, i in intervals.items()])"
    ],
    "metadata": {
     "collapsed": false
@@ -209,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "outputs": [],
    "source": [
     "def time_tuples_to_periods(\n",
@@ -250,56 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "outputs": [],
-   "source": [
-    "def make_status_intervals(df: PeriodTable) -> dict[str, P.interval]:\n",
-    "    return {s: df_to_interval(df[df.status == s]) for s in df.status.unique()}"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "outputs": [],
-   "source": [
-    "def interval_merge_logic(lt: dict[str, P.interval], oo: dict[str, P.interval]) -> dict[str, P.interval]:\n",
-    "    P3 = lt['P3'] | oo['P3']\n",
-    "    P2 = (lt['P2'] | oo['P2']) - P3\n",
-    "    P1 = oo['P1'] - (P2 | P3)\n",
-    "    return {'P1': P1, 'P2': P2, 'P3': P3}"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "outputs": [],
-   "source": [
-    "def main_interval_logic(lt: dict[str, P.interval], oo: dict[str, P.interval], P0_has_priority=False) -> Table:\n",
-    "    \"\"\"Consider the following ordering of priorities: P3 > P2 > P1. P0_has_priority determines if P0 is on the left or right of inequalities.\"\"\"\n",
-    "    if P0_has_priority:\n",
-    "        for d in [lt, oo]:\n",
-    "            for k in d.keys():\n",
-    "                if k != 'P0':\n",
-    "                    d[k] = d[k] - oo['P0']\n",
-    "    lt['P2'] = lt['P2'] - lt['P3']\n",
-    "    oo['P2'] = oo['P2'] - oo['P3']\n",
-    "    oo['P1'] = oo['P1'] - (oo['P2'] | oo['P3'])\n",
-    "    intervals = interval_merge_logic(lt, oo)\n",
-    "    return pd.concat([interval_to_df(i).assign(status=f'{s} consistent') for s, i in intervals.items()])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "outputs": [],
    "source": [
     "def merge_overlapping_intervals(table: PeriodTable, agg_dict: Optional[dict] = None) -> PeriodTable:\n",
@@ -311,19 +283,19 @@
     "    \"\"\"\n",
     "    agg_dict = agg_dict or {c: 'sum' for c in table.columns if c not in ['begin', 'end', 'status']}\n",
     "\n",
-    "    def handle_groups(table: PeriodTable) -> PeriodTable:\n",
-    "        intervals = table[['begin', 'end']].sort_values(['begin', 'end'])\n",
-    "        group = 0\n",
+    "    def handle_groups(group: PeriodTable) -> PeriodTable:\n",
+    "        intervals = group[['begin', 'end']].sort_values(['begin', 'end'])\n",
+    "        group_number = 0\n",
     "        group_end = intervals.end.iloc[0]\n",
     "\n",
     "        def find_group(row):\n",
-    "            nonlocal group, group_end\n",
+    "            nonlocal group_number, group_end\n",
     "            if row.begin <= group_end:\n",
     "                group_end = max(row.end, group_end)\n",
     "            else:\n",
-    "                group += 1\n",
+    "                group_number += 1\n",
     "                group_end = row.end\n",
-    "            return group\n",
+    "            return group_number\n",
     "\n",
     "        groups = intervals.apply(find_group, axis=1)\n",
     "        return table.groupby(groups).agg({'begin': 'min', 'end': 'max', **agg_dict}).reset_index(drop=True)\n",
@@ -336,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "outputs": [],
    "source": [
     "def mile2km(n_miles: float) -> float:\n",
@@ -357,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "outputs": [],
    "source": [
     "def load_lifetime_trips(folder: Path, pattern: str = '*Driver Lifetime Trips.csv') -> PeriodTable:\n",
@@ -386,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 14,
    "outputs": [],
    "source": [
     "def load_on_off(folder: Path, pattern: str = '*Driver Online Offline.csv') -> PeriodTable:\n",
@@ -406,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 15,
    "outputs": [],
    "source": [
     "def load_dispatches(folder: Path, pattern: str = 'TODO') -> Table:\n",
@@ -423,7 +395,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 16,
    "outputs": [],
    "source": [
     "def load_trip_status(folder: Path, pattern: str = '*Driver Trip Status.csv') -> PeriodTable:\n",
@@ -438,9 +410,7 @@
    }
   },
   {
-   "cell_type": "code",
-   "execution_count": 21,
-   "outputs": [],
+   "cell_type": "markdown",
    "source": [
     "def load_distance_traveled(folder: Path, pattern: str = 'TODO') -> pd.DataFrame:\n",
     "    pass  # TODO"
@@ -451,7 +421,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 17,
    "outputs": [],
    "source": [
     "def load_sar(folder: Path) -> Table:\n",
@@ -474,7 +444,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 18,
    "outputs": [],
    "source": [
     "def load_portal(folder: Path):\n",
@@ -505,36 +475,38 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 126,
+   "execution_count": 19,
    "outputs": [],
    "source": [
     "def guillaume_filtering_logic(\n",
     "        daily: Table,\n",
     "        percentage_df_path: Optional[str | Path] = data_folder / 'Guillaume' / 'percentage.csv'\n",
     ") -> Table:\n",
-    "    # TODO fix, not working anymore\n",
     "    # First, weight P1 times based on the percentage that Guillaume was working for Uber on that month\n",
     "    percentage = pd.read_csv(percentage_df_path)\n",
     "    percentage['Uber'] /= 100\n",
-    "    daily['datetime'] = pd.to_datetime(daily['date'])\n",
-    "    duration_P1_cols = list(filter(lambda c: 'duration_P1' in c and 'AM' in c and 'weekday' in c, daily.columns))\n",
-    "    new_cols = []\n",
+    "    filtered = pd.DataFrame(index=daily.index)\n",
+    "    filtered['datetime'] = pd.to_datetime(daily['date'])\n",
+    "    duration_P1_cols = list(filter(lambda col: all(f in col for f in ['duration_h', 'P1']), daily.columns))\n",
     "    for c in duration_P1_cols:\n",
     "        for i, row in percentage.iterrows():\n",
-    "            daily[f'{c}(filtered)'] = np.where(\n",
-    "                (daily.datetime.dt.year == row.year) & (daily.datetime.dt.month == row.month),\n",
+    "            filtered[c] = np.where(\n",
+    "                (filtered.datetime.dt.year == row.year) & (filtered.datetime.dt.month == row.month),\n",
     "                daily[c] * row['Uber'], daily[c])\n",
-    "        new_cols.append(f'{c}(filtered)')\n",
+    "\n",
+    "    def date_range(from_date: Tuple[int, ...], to_date: Tuple[int, ...]) -> list[datetime.date]:\n",
+    "        return pd.date_range(datetime.date(*from_date), datetime.date(*to_date)).values\n",
+    "\n",
     "    # Second, remove all morning weekday entries when Guillaume was working for IMAD, except for the specific dates below\n",
-    "    dates_to_keep = [datetime.date(2020, 11, 26),\n",
-    "                     *pd.date_range(datetime.date(2020, 12, 21), datetime.date(2020, 12, 25)).values,\n",
-    "                     *pd.date_range(datetime.date(2021, 2, 1), datetime.date(2021, 2, 12)).values,\n",
-    "                     *pd.date_range(datetime.date(2021, 8, 16), datetime.date(2021, 8, 28)).values,\n",
-    "                     *pd.date_range(datetime.date(2021, 9, 20), datetime.date(2021, 10, 3)).values,\n",
-    "                     *pd.date_range(datetime.date(2021, 11, 25), datetime.date(2021, 12, 12)).values,\n",
-    "                     *pd.date_range(datetime.date(2022, 4, 25), datetime.date(2022, 5, 13)).values]\n",
-    "    daily.loc[daily[~daily.datetime.apply(lambda d: d.date()).isin(dates_to_keep)].index, new_cols] = 0\n",
-    "    return daily[new_cols]"
+    "    dates_to_keep = [datetime.date(2020, 11, 26), *date_range((2020, 12, 21), (2020, 12, 25)),\n",
+    "                     *date_range((2021, 2, 1), (2021, 2, 12)), *date_range((2021, 8, 16), (2021, 8, 28)),\n",
+    "                     *date_range((2021, 9, 20), (2021, 10, 3)), *date_range((2021, 11, 25), (2021, 12, 12)),\n",
+    "                     *date_range((2022, 4, 25), (2022, 5, 13))]\n",
+    "    duration_P1_weekday_AM_cols = list(\n",
+    "        filter(lambda col: all(f in col for f in ['duration_h', 'P1', 'AM', 'weekday']), daily.columns))\n",
+    "    filtered.loc[\n",
+    "        daily[~filtered.datetime.apply(lambda d: d.date()).isin(dates_to_keep)].index, duration_P1_weekday_AM_cols] = 0\n",
+    "    return filtered[duration_P1_cols].rename(columns={col: f'{col}(filtered)' for col in duration_P1_cols})"
    ],
    "metadata": {
     "collapsed": false
@@ -542,7 +514,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 20,
    "outputs": [],
    "source": [
     "def split_AM_PM(table: PeriodTable) -> PeriodTable:\n",
@@ -586,7 +558,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 21,
    "outputs": [],
    "source": [
     "def split_hours(table: PeriodTable) -> PeriodTable:\n",
@@ -624,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 22,
    "outputs": [],
    "source": [
     "def find_week_limits(date: Timestamp) -> str:\n",
@@ -638,7 +610,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 23,
    "outputs": [],
    "source": [
     "def select(d: dict[str], keep: Optional[list[str]] = None, drop: Optional[list[str]] = None) -> dict[str]:\n",
@@ -663,7 +635,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 120,
+   "execution_count": 24,
    "outputs": [],
    "source": [
     "all_facets = ['duration_h', 'distance_km', 'uber_paid']\n",
@@ -678,7 +650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 138,
+   "execution_count": 25,
    "outputs": [],
    "source": [
     "def pipeline(\n",
@@ -689,6 +661,7 @@
     "        name: str = 'analysis',\n",
     "        facets: list[str] = all_facets,\n",
     "        save_at: Path = data_folder / 'results',\n",
+    "        compute_most_lucrative_months: bool = True,\n",
     ") -> Tuple[pd.DataFrame, ...]:\n",
     "    # Apply interval logic if specified\n",
     "    if interval_logic is not None:\n",
@@ -699,14 +672,11 @@
     "    # Split intervals spanning many hours\n",
     "    periods = split_hours(periods)\n",
     "\n",
-    "    counts = periods[['begin', 'end']].value_counts()\n",
-    "    duplicates = counts[counts > 1].reset_index()\n",
-    "    display(periods[periods.begin.isin(duplicates.begin) & periods.end.isin(duplicates.end)])\n",
-    "\n",
     "    # Pivot table so that each there is a single line per interval and per granularity of interest\n",
     "    periods = periods.pivot(index=['begin', 'end'], columns=['status'], values=facets).reset_index()\n",
     "    periods[periods == 0] = np.nan\n",
-    "    periods.drop(columns=periods.columns[periods.isna().all()], inplace=True)  # this and previous remove columns that have only 0/nans\n",
+    "    periods.drop(columns=periods.columns[periods.isna().all()],\n",
+    "                 inplace=True)  # this and previous remove columns that have only 0/nans\n",
     "    # Merges column multiindex into a single index by joining the levels\n",
     "    periods.columns = periods.columns.map(lambda t: '.'.join(t) if t[1] else t[0])\n",
     "\n",
@@ -720,7 +690,9 @@
     "            periods[k] = periods.end.apply(f)\n",
     "        periods = periods.pivot(index=['begin', 'end'], columns=date_info, values=list(agg_dict.keys())).reset_index()\n",
     "        periods.columns = periods.columns.map(lambda t: '.'.join(t) if t[1] else t[0])\n",
-    "        agg_dict = {c: 'sum' for c in periods.columns if any(f in c for f in facets)}\n",
+    "\n",
+    "    agg_dict = {c: 'sum' for c in periods.columns if any(f in c for f in facets)}\n",
+    "\n",
     "    periods['hour'] = periods.end.apply(lambda d: f'{d.hour}-{(d + datetime.timedelta(hours=1)).hour}')\n",
     "    periods['date'] = periods.end.dt.date\n",
     "    periods['week'] = periods.end.apply(find_week_limits)\n",
@@ -728,26 +700,35 @@
     "    periods['year'] = periods.end.dt.year\n",
     "\n",
     "    hourly = periods.groupby(['date', 'hour']).agg(agg_dict).reset_index()\n",
-    "    daily = periods.groupby(['date']).agg(agg_dict).reset_index()\n",
+    "    daily = periods.groupby(['date', 'year', 'month', 'week']).agg(agg_dict).reset_index()\n",
     "\n",
     "    # Filter the data if a filtering function is specified\n",
     "    if filtering_logic is not None:\n",
-    "        daily = pd.concat([daily, filtering_logic(daily)], axis=1)\n",
+    "        filtered = filtering_logic(daily)\n",
+    "        daily = pd.concat([daily, filtered], axis=1)\n",
+    "        agg_dict = {**agg_dict, **{c: 'sum' for c in filtered.columns}}\n",
     "\n",
-    "    weekly = periods.groupby(['week']).agg(agg_dict).reset_index()\n",
-    "    monthly = periods.groupby(['year', 'month']).agg(agg_dict).reset_index()\n",
-    "    yearly = periods.groupby(['year']).agg(agg_dict).reset_index()\n",
+    "    weekly = daily.groupby(['week']).agg(agg_dict).reset_index()\n",
+    "    monthly = daily.groupby(['year', 'month']).agg(agg_dict).reset_index()\n",
+    "    yearly = daily.groupby(['year']).agg(agg_dict).reset_index()\n",
     "    total = yearly.agg(agg_dict).to_frame().T\n",
+    "\n",
+    "    if compute_most_lucrative_months:\n",
+    "        most_lucrative_months: Table = monthly.copy()\n",
+    "        most_lucrative_months['uber_paid_total'] = monthly[[c for c in monthly.columns if 'uber_paid' in c]].sum(axis=1)\n",
+    "        most_lucrative_months.sort_values('uber_paid_total', ascending=False, inplace=True)\n",
+    "        most_lucrative_months.to_csv(save_at / f'{name}_4_bis_most_lucrative_months.csv', index=False,\n",
+    "                                     float_format='%.2f')\n",
     "\n",
     "    # Writing tables to disk\n",
     "    save_at.mkdir(parents=True, exist_ok=True)\n",
-    "    periods.to_csv(save_at / f'0_{name}_periods.csv', index=False, float_format='%.3f')\n",
-    "    hourly.to_csv(save_at / f'1_{name}_hourly.csv', index=False, float_format='%.3f')\n",
-    "    daily.to_csv(save_at / f'2_{name}_daily.csv', index=False, float_format='%.3f')\n",
-    "    weekly.to_csv(save_at / f'3_{name}_weekly.csv', index=False, float_format='%.3f')\n",
-    "    monthly.to_csv(save_at / f'4_{name}_monthly.csv', index=False, float_format='%.3f')\n",
-    "    yearly.to_csv(save_at / f'5_{name}_yearly.csv', index=False, float_format='%.3f')\n",
-    "    total.to_csv(save_at / f'6_{name}_total.csv', index=False, float_format='%.3f')\n",
+    "    periods.to_csv(save_at / f'{name}_0_periods.csv', index=False, float_format='%.2f')\n",
+    "    hourly.to_csv(save_at / f'{name}_1_hourly.csv', index=False, float_format='%.2f')\n",
+    "    daily.to_csv(save_at / f'{name}_2_daily.csv', index=False, float_format='%.2f')\n",
+    "    weekly.to_csv(save_at / f'{name}_3_weekly.csv', index=False, float_format='%.2f')\n",
+    "    monthly.to_csv(save_at / f'{name}_4_monthly.csv', index=False, float_format='%.2f')\n",
+    "    yearly.to_csv(save_at / f'{name}_5_yearly.csv', index=False, float_format='%.2f')\n",
+    "    total.to_csv(save_at / f'{name}_6_total.csv', index=False, float_format='%.2f')\n",
     "\n",
     "    return hourly, daily, weekly, yearly, total"
    ],
@@ -768,13 +749,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 129,
+   "execution_count": 26,
    "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Guillaume' / 'raw' / 'SAR (new)'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
     "             filtering_logic=guillaume_filtering_logic,\n",
-    "             name='sar', time_properties=select(all_time_properties, keep=['time_of_day']),\n",
+    "             name='sar', time_properties=select(all_time_properties, keep=['time_of_day', 'day_type']),\n",
     "             save_at=data_folder / 'Guillaume' / 'results')"
    ],
    "metadata": {
@@ -783,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 130,
+   "execution_count": 27,
    "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Kidane' / 'raw' / 'SAR'),\n",
@@ -797,16 +778,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 139,
+   "execution_count": 28,
    "outputs": [
-    {
-     "data": {
-      "text/plain": "                          begin                       end status  uber_paid  \\\n54915 2021-08-29 18:00:00+00:00 2021-08-29 18:00:38+00:00     P2   0.000000   \n54957 2021-08-31 11:00:00+00:00 2021-08-31 11:04:43+00:00     P2   0.000000   \n55026 2021-09-02 17:00:00+00:00 2021-09-02 17:02:45+00:00     P2   0.000000   \n55081 2021-09-06 16:00:00+00:00 2021-09-06 16:00:04+00:00     P2   0.000000   \n55195 2021-09-11 21:00:00+00:00 2021-09-11 21:00:09+00:00     P2   0.000000   \n73247 2021-08-29 18:00:00+00:00 2021-08-29 18:00:38+00:00     P3   1.231030   \n73274 2021-08-31 11:00:00+00:00 2021-08-31 11:04:43+00:00     P3   4.823799   \n73323 2021-09-02 17:00:00+00:00 2021-09-02 17:02:45+00:00     P3   8.644030   \n73359 2021-09-06 16:00:00+00:00 2021-09-06 16:00:04+00:00     P3   0.158475   \n73426 2021-09-11 21:00:00+00:00 2021-09-11 21:00:09+00:00     P3   0.338265   \n78214 2022-10-30 02:48:01+00:00 2022-10-30 02:01:47+00:00     P3  46.100000   \n78215 2022-10-30 02:48:01+00:00 2022-10-30 02:01:47+00:00     P3   0.000000   \n\n       distance_km  duration_h  \n54915     0.000000    0.010556  \n54957     0.000000    0.078611  \n55026     0.003945    0.045833  \n55081     0.000000    0.001111  \n55195     0.000000    0.002500  \n73247     0.248395    0.010556  \n73274     1.065423    0.078611  \n73323     1.113123    0.045833  \n73359     0.022923    0.001111  \n73426     0.056242    0.002500  \n78214     6.515524   -0.770556  \n78215     0.000000   -0.770556  ",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>begin</th>\n      <th>end</th>\n      <th>status</th>\n      <th>uber_paid</th>\n      <th>distance_km</th>\n      <th>duration_h</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>54915</th>\n      <td>2021-08-29 18:00:00+00:00</td>\n      <td>2021-08-29 18:00:38+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.010556</td>\n    </tr>\n    <tr>\n      <th>54957</th>\n      <td>2021-08-31 11:00:00+00:00</td>\n      <td>2021-08-31 11:04:43+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.078611</td>\n    </tr>\n    <tr>\n      <th>55026</th>\n      <td>2021-09-02 17:00:00+00:00</td>\n      <td>2021-09-02 17:02:45+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.003945</td>\n      <td>0.045833</td>\n    </tr>\n    <tr>\n      <th>55081</th>\n      <td>2021-09-06 16:00:00+00:00</td>\n      <td>2021-09-06 16:00:04+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.001111</td>\n    </tr>\n    <tr>\n      <th>55195</th>\n      <td>2021-09-11 21:00:00+00:00</td>\n      <td>2021-09-11 21:00:09+00:00</td>\n      <td>P2</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>0.002500</td>\n    </tr>\n    <tr>\n      <th>73247</th>\n      <td>2021-08-29 18:00:00+00:00</td>\n      <td>2021-08-29 18:00:38+00:00</td>\n      <td>P3</td>\n      <td>1.231030</td>\n      <td>0.248395</td>\n      <td>0.010556</td>\n    </tr>\n    <tr>\n      <th>73274</th>\n      <td>2021-08-31 11:00:00+00:00</td>\n      <td>2021-08-31 11:04:43+00:00</td>\n      <td>P3</td>\n      <td>4.823799</td>\n      <td>1.065423</td>\n      <td>0.078611</td>\n    </tr>\n    <tr>\n      <th>73323</th>\n      <td>2021-09-02 17:00:00+00:00</td>\n      <td>2021-09-02 17:02:45+00:00</td>\n      <td>P3</td>\n      <td>8.644030</td>\n      <td>1.113123</td>\n      <td>0.045833</td>\n    </tr>\n    <tr>\n      <th>73359</th>\n      <td>2021-09-06 16:00:00+00:00</td>\n      <td>2021-09-06 16:00:04+00:00</td>\n      <td>P3</td>\n      <td>0.158475</td>\n      <td>0.022923</td>\n      <td>0.001111</td>\n    </tr>\n    <tr>\n      <th>73426</th>\n      <td>2021-09-11 21:00:00+00:00</td>\n      <td>2021-09-11 21:00:09+00:00</td>\n      <td>P3</td>\n      <td>0.338265</td>\n      <td>0.056242</td>\n      <td>0.002500</td>\n    </tr>\n    <tr>\n      <th>78214</th>\n      <td>2022-10-30 02:48:01+00:00</td>\n      <td>2022-10-30 02:01:47+00:00</td>\n      <td>P3</td>\n      <td>46.100000</td>\n      <td>6.515524</td>\n      <td>-0.770556</td>\n    </tr>\n    <tr>\n      <th>78215</th>\n      <td>2022-10-30 02:48:01+00:00</td>\n      <td>2022-10-30 02:01:47+00:00</td>\n      <td>P3</td>\n      <td>0.000000</td>\n      <td>0.000000</td>\n      <td>-0.770556</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "ename": "ValueError",
      "evalue": "Index contains duplicate entries, cannot reshape",
@@ -814,15 +787,17 @@
      "traceback": [
       "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
       "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
-      "Input \u001B[0;32mIn [139]\u001B[0m, in \u001B[0;36m<cell line: 1>\u001B[0;34m()\u001B[0m\n\u001B[0;32m----> 1\u001B[0m _ \u001B[38;5;241m=\u001B[39m \u001B[43mpipeline\u001B[49m\u001B[43m(\u001B[49m\u001B[43mload_sar\u001B[49m\u001B[43m(\u001B[49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mraw\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mSAR\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      2\u001B[0m \u001B[43m             \u001B[49m\u001B[43minterval_logic\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;28;43;01mlambda\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mt\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[43mmerge_overlapping_intervals\u001B[49m\u001B[43m(\u001B[49m\u001B[43mt\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43m{\u001B[49m\u001B[43mc\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msum\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;28;43;01mfor\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mc\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;129;43;01min\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43muber_paid\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mdistance_km\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m}\u001B[49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      3\u001B[0m \u001B[43m             \u001B[49m\u001B[43mname\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msar\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mtime_properties\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mall_time_properties\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m             \u001B[49m\u001B[43msave_at\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mresults\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\n",
-      "Input \u001B[0;32mIn [138]\u001B[0m, in \u001B[0;36mpipeline\u001B[0;34m(periods, interval_logic, filtering_logic, time_properties, name, facets, save_at)\u001B[0m\n\u001B[1;32m     21\u001B[0m display(periods[periods\u001B[38;5;241m.\u001B[39mbegin\u001B[38;5;241m.\u001B[39misin(duplicates\u001B[38;5;241m.\u001B[39mbegin) \u001B[38;5;241m&\u001B[39m periods\u001B[38;5;241m.\u001B[39mend\u001B[38;5;241m.\u001B[39misin(duplicates\u001B[38;5;241m.\u001B[39mend)])\n\u001B[1;32m     23\u001B[0m \u001B[38;5;66;03m# Pivot table so that each there is a single line per interval and per granularity of interest\u001B[39;00m\n\u001B[0;32m---> 24\u001B[0m periods \u001B[38;5;241m=\u001B[39m \u001B[43mperiods\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mbegin\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mend\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mstatus\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfacets\u001B[49m\u001B[43m)\u001B[49m\u001B[38;5;241m.\u001B[39mreset_index()\n\u001B[1;32m     25\u001B[0m periods[periods \u001B[38;5;241m==\u001B[39m \u001B[38;5;241m0\u001B[39m] \u001B[38;5;241m=\u001B[39m np\u001B[38;5;241m.\u001B[39mnan\n\u001B[1;32m     26\u001B[0m periods\u001B[38;5;241m.\u001B[39mdrop(columns\u001B[38;5;241m=\u001B[39mperiods\u001B[38;5;241m.\u001B[39mcolumns[periods\u001B[38;5;241m.\u001B[39misna()\u001B[38;5;241m.\u001B[39mall()], inplace\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mTrue\u001B[39;00m)  \u001B[38;5;66;03m# this and previous remove columns that have only 0/nans\u001B[39;00m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/frame.py:7885\u001B[0m, in \u001B[0;36mDataFrame.pivot\u001B[0;34m(self, index, columns, values)\u001B[0m\n\u001B[1;32m   7880\u001B[0m \u001B[38;5;129m@Substitution\u001B[39m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m   7881\u001B[0m \u001B[38;5;129m@Appender\u001B[39m(_shared_docs[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpivot\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   7882\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mpivot\u001B[39m(\u001B[38;5;28mself\u001B[39m, index\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, columns\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, values\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m DataFrame:\n\u001B[1;32m   7883\u001B[0m     \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mpivot\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m pivot\n\u001B[0;32m-> 7885\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mcolumns\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mvalues\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/pivot.py:520\u001B[0m, in \u001B[0;36mpivot\u001B[0;34m(data, index, columns, values)\u001B[0m\n\u001B[1;32m    518\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    519\u001B[0m         indexed \u001B[38;5;241m=\u001B[39m data\u001B[38;5;241m.\u001B[39m_constructor_sliced(data[values]\u001B[38;5;241m.\u001B[39m_values, index\u001B[38;5;241m=\u001B[39mmultiindex)\n\u001B[0;32m--> 520\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mindexed\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[43mcolumns_listlike\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/frame.py:8428\u001B[0m, in \u001B[0;36mDataFrame.unstack\u001B[0;34m(self, level, fill_value)\u001B[0m\n\u001B[1;32m   8366\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   8367\u001B[0m \u001B[38;5;124;03mPivot a level of the (necessarily hierarchical) index labels.\u001B[39;00m\n\u001B[1;32m   8368\u001B[0m \n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m   8424\u001B[0m \u001B[38;5;124;03mdtype: float64\u001B[39;00m\n\u001B[1;32m   8425\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   8426\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m unstack\n\u001B[0;32m-> 8428\u001B[0m result \u001B[38;5;241m=\u001B[39m \u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m   8430\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m result\u001B[38;5;241m.\u001B[39m__finalize__(\u001B[38;5;28mself\u001B[39m, method\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124munstack\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:478\u001B[0m, in \u001B[0;36munstack\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    476\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj, DataFrame):\n\u001B[1;32m    477\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex):\n\u001B[0;32m--> 478\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43m_unstack_frame\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    479\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    480\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39mT\u001B[38;5;241m.\u001B[39mstack(dropna\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m)\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:505\u001B[0m, in \u001B[0;36m_unstack_frame\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    503\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39m_constructor(mgr)\n\u001B[1;32m    504\u001B[0m \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[0;32m--> 505\u001B[0m     unstacker \u001B[38;5;241m=\u001B[39m \u001B[43m_Unstacker\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mconstructor\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_constructor\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    506\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m unstacker\u001B[38;5;241m.\u001B[39mget_result(\n\u001B[1;32m    507\u001B[0m         obj\u001B[38;5;241m.\u001B[39m_values, value_columns\u001B[38;5;241m=\u001B[39mobj\u001B[38;5;241m.\u001B[39mcolumns, fill_value\u001B[38;5;241m=\u001B[39mfill_value\n\u001B[1;32m    508\u001B[0m     )\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:140\u001B[0m, in \u001B[0;36m_Unstacker.__init__\u001B[0;34m(self, index, level, constructor)\u001B[0m\n\u001B[1;32m    133\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m num_cells \u001B[38;5;241m>\u001B[39m np\u001B[38;5;241m.\u001B[39miinfo(np\u001B[38;5;241m.\u001B[39mint32)\u001B[38;5;241m.\u001B[39mmax:\n\u001B[1;32m    134\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    135\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mThe following operation may generate \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mnum_cells\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m cells \u001B[39m\u001B[38;5;124m\"\u001B[39m\n\u001B[1;32m    136\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124min the resulting pandas object.\u001B[39m\u001B[38;5;124m\"\u001B[39m,\n\u001B[1;32m    137\u001B[0m         PerformanceWarning,\n\u001B[1;32m    138\u001B[0m     )\n\u001B[0;32m--> 140\u001B[0m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_make_selectors\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.10/site-packages/pandas/core/reshape/reshape.py:192\u001B[0m, in \u001B[0;36m_Unstacker._make_selectors\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    189\u001B[0m mask\u001B[38;5;241m.\u001B[39mput(selector, \u001B[38;5;28;01mTrue\u001B[39;00m)\n\u001B[1;32m    191\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m mask\u001B[38;5;241m.\u001B[39msum() \u001B[38;5;241m<\u001B[39m \u001B[38;5;28mlen\u001B[39m(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mindex):\n\u001B[0;32m--> 192\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mIndex contains duplicate entries, cannot reshape\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    194\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mgroup_index \u001B[38;5;241m=\u001B[39m comp_index\n\u001B[1;32m    195\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mmask \u001B[38;5;241m=\u001B[39m mask\n",
+      "Cell \u001B[0;32mIn[28], line 1\u001B[0m\n\u001B[0;32m----> 1\u001B[0m _ \u001B[38;5;241m=\u001B[39m \u001B[43mpipeline\u001B[49m\u001B[43m(\u001B[49m\u001B[43mload_sar\u001B[49m\u001B[43m(\u001B[49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mraw\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mSAR\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      2\u001B[0m \u001B[43m             \u001B[49m\u001B[43minterval_logic\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;28;43;01mlambda\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mt\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[43mmerge_overlapping_intervals\u001B[49m\u001B[43m(\u001B[49m\u001B[43mt\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43m{\u001B[49m\u001B[43mc\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msum\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;28;43;01mfor\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mc\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;129;43;01min\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43muber_paid\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mdistance_km\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m}\u001B[49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      3\u001B[0m \u001B[43m             \u001B[49m\u001B[43mname\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msar\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mtime_properties\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mall_time_properties\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m             \u001B[49m\u001B[43msave_at\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mresults\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\n",
+      "Cell \u001B[0;32mIn[25], line 21\u001B[0m, in \u001B[0;36mpipeline\u001B[0;34m(periods, interval_logic, filtering_logic, time_properties, name, facets, save_at, compute_monthly_top_10)\u001B[0m\n\u001B[1;32m     18\u001B[0m periods \u001B[38;5;241m=\u001B[39m split_hours(periods)\n\u001B[1;32m     20\u001B[0m \u001B[38;5;66;03m# Pivot table so that each there is a single line per interval and per granularity of interest\u001B[39;00m\n\u001B[0;32m---> 21\u001B[0m periods \u001B[38;5;241m=\u001B[39m \u001B[43mperiods\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mbegin\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mend\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mstatus\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfacets\u001B[49m\u001B[43m)\u001B[49m\u001B[38;5;241m.\u001B[39mreset_index()\n\u001B[1;32m     22\u001B[0m periods[periods \u001B[38;5;241m==\u001B[39m \u001B[38;5;241m0\u001B[39m] \u001B[38;5;241m=\u001B[39m np\u001B[38;5;241m.\u001B[39mnan\n\u001B[1;32m     23\u001B[0m periods\u001B[38;5;241m.\u001B[39mdrop(columns\u001B[38;5;241m=\u001B[39mperiods\u001B[38;5;241m.\u001B[39mcolumns[periods\u001B[38;5;241m.\u001B[39misna()\u001B[38;5;241m.\u001B[39mall()],\n\u001B[1;32m     24\u001B[0m              inplace\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mTrue\u001B[39;00m)  \u001B[38;5;66;03m# this and previous remove columns that have only 0/nans\u001B[39;00m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/util/_decorators.py:331\u001B[0m, in \u001B[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001B[0;34m(*args, **kwargs)\u001B[0m\n\u001B[1;32m    325\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28mlen\u001B[39m(args) \u001B[38;5;241m>\u001B[39m num_allow_args:\n\u001B[1;32m    326\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    327\u001B[0m         msg\u001B[38;5;241m.\u001B[39mformat(arguments\u001B[38;5;241m=\u001B[39m_format_argument_list(allow_args)),\n\u001B[1;32m    328\u001B[0m         \u001B[38;5;167;01mFutureWarning\u001B[39;00m,\n\u001B[1;32m    329\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    330\u001B[0m     )\n\u001B[0;32m--> 331\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mfunc\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43margs\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/frame.py:8564\u001B[0m, in \u001B[0;36mDataFrame.pivot\u001B[0;34m(self, index, columns, values)\u001B[0m\n\u001B[1;32m   8558\u001B[0m \u001B[38;5;129m@Substitution\u001B[39m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m   8559\u001B[0m \u001B[38;5;129m@Appender\u001B[39m(_shared_docs[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpivot\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   8560\u001B[0m \u001B[38;5;129m@deprecate_nonkeyword_arguments\u001B[39m(version\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, allowed_args\u001B[38;5;241m=\u001B[39m[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mself\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   8561\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mpivot\u001B[39m(\u001B[38;5;28mself\u001B[39m, index\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, columns\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, values\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m DataFrame:\n\u001B[1;32m   8562\u001B[0m     \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mpivot\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m pivot\n\u001B[0;32m-> 8564\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mcolumns\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mvalues\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/util/_decorators.py:331\u001B[0m, in \u001B[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001B[0;34m(*args, **kwargs)\u001B[0m\n\u001B[1;32m    325\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28mlen\u001B[39m(args) \u001B[38;5;241m>\u001B[39m num_allow_args:\n\u001B[1;32m    326\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    327\u001B[0m         msg\u001B[38;5;241m.\u001B[39mformat(arguments\u001B[38;5;241m=\u001B[39m_format_argument_list(allow_args)),\n\u001B[1;32m    328\u001B[0m         \u001B[38;5;167;01mFutureWarning\u001B[39;00m,\n\u001B[1;32m    329\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    330\u001B[0m     )\n\u001B[0;32m--> 331\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mfunc\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43margs\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/pivot.py:540\u001B[0m, in \u001B[0;36mpivot\u001B[0;34m(data, index, columns, values)\u001B[0m\n\u001B[1;32m    536\u001B[0m         indexed \u001B[38;5;241m=\u001B[39m data\u001B[38;5;241m.\u001B[39m_constructor_sliced(data[values]\u001B[38;5;241m.\u001B[39m_values, index\u001B[38;5;241m=\u001B[39mmultiindex)\n\u001B[1;32m    537\u001B[0m \u001B[38;5;66;03m# error: Argument 1 to \"unstack\" of \"DataFrame\" has incompatible type \"Union\u001B[39;00m\n\u001B[1;32m    538\u001B[0m \u001B[38;5;66;03m# [List[Any], ExtensionArray, ndarray[Any, Any], Index, Series]\"; expected\u001B[39;00m\n\u001B[1;32m    539\u001B[0m \u001B[38;5;66;03m# \"Hashable\"\u001B[39;00m\n\u001B[0;32m--> 540\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mindexed\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[43mcolumns_listlike\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/frame.py:9109\u001B[0m, in \u001B[0;36mDataFrame.unstack\u001B[0;34m(self, level, fill_value)\u001B[0m\n\u001B[1;32m   9047\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   9048\u001B[0m \u001B[38;5;124;03mPivot a level of the (necessarily hierarchical) index labels.\u001B[39;00m\n\u001B[1;32m   9049\u001B[0m \n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m   9105\u001B[0m \u001B[38;5;124;03mdtype: float64\u001B[39;00m\n\u001B[1;32m   9106\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   9107\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m unstack\n\u001B[0;32m-> 9109\u001B[0m result \u001B[38;5;241m=\u001B[39m \u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m   9111\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m result\u001B[38;5;241m.\u001B[39m__finalize__(\u001B[38;5;28mself\u001B[39m, method\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124munstack\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:476\u001B[0m, in \u001B[0;36munstack\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    474\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj, DataFrame):\n\u001B[1;32m    475\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex):\n\u001B[0;32m--> 476\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43m_unstack_frame\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    477\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    478\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39mT\u001B[38;5;241m.\u001B[39mstack(dropna\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m)\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:499\u001B[0m, in \u001B[0;36m_unstack_frame\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    497\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21m_unstack_frame\u001B[39m(obj: DataFrame, level, fill_value\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m):\n\u001B[1;32m    498\u001B[0m     \u001B[38;5;28;01massert\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex)  \u001B[38;5;66;03m# checked by caller\u001B[39;00m\n\u001B[0;32m--> 499\u001B[0m     unstacker \u001B[38;5;241m=\u001B[39m \u001B[43m_Unstacker\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mconstructor\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_constructor\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    501\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m obj\u001B[38;5;241m.\u001B[39m_can_fast_transpose:\n\u001B[1;32m    502\u001B[0m         mgr \u001B[38;5;241m=\u001B[39m obj\u001B[38;5;241m.\u001B[39m_mgr\u001B[38;5;241m.\u001B[39munstack(unstacker, fill_value\u001B[38;5;241m=\u001B[39mfill_value)\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:137\u001B[0m, in \u001B[0;36m_Unstacker.__init__\u001B[0;34m(self, index, level, constructor)\u001B[0m\n\u001B[1;32m    129\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m num_cells \u001B[38;5;241m>\u001B[39m np\u001B[38;5;241m.\u001B[39miinfo(np\u001B[38;5;241m.\u001B[39mint32)\u001B[38;5;241m.\u001B[39mmax:\n\u001B[1;32m    130\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    131\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mThe following operation may generate \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mnum_cells\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m cells \u001B[39m\u001B[38;5;124m\"\u001B[39m\n\u001B[1;32m    132\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124min the resulting pandas object.\u001B[39m\u001B[38;5;124m\"\u001B[39m,\n\u001B[1;32m    133\u001B[0m         PerformanceWarning,\n\u001B[1;32m    134\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    135\u001B[0m     )\n\u001B[0;32m--> 137\u001B[0m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_make_selectors\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n",
+      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:189\u001B[0m, in \u001B[0;36m_Unstacker._make_selectors\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    186\u001B[0m mask\u001B[38;5;241m.\u001B[39mput(selector, \u001B[38;5;28;01mTrue\u001B[39;00m)\n\u001B[1;32m    188\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m mask\u001B[38;5;241m.\u001B[39msum() \u001B[38;5;241m<\u001B[39m \u001B[38;5;28mlen\u001B[39m(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mindex):\n\u001B[0;32m--> 189\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mIndex contains duplicate entries, cannot reshape\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    191\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mgroup_index \u001B[38;5;241m=\u001B[39m comp_index\n\u001B[1;32m    192\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mmask \u001B[38;5;241m=\u001B[39m mask\n",
       "\u001B[0;31mValueError\u001B[0m: Index contains duplicate entries, cannot reshape"
      ]
     }
@@ -848,7 +823,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 132,
+   "execution_count": 29,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Guillaume' / 'raw' / 'Portal' / 'Driver'),\n",
@@ -862,7 +837,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 133,
+   "execution_count": 30,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Aria' / 'raw' / 'Portal' / 'Driver'),\n",

--- a/Analysis.ipynb
+++ b/Analysis.ipynb
@@ -35,15 +35,17 @@
       "Requirement already satisfied: numpy in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (1.23.5)\r\n",
       "Requirement already satisfied: pandas in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (1.5.2)\r\n",
       "Requirement already satisfied: portion in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (2.3.0)\r\n",
+      "Requirement already satisfied: openpyxl in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (3.0.10)\r\n",
       "Requirement already satisfied: python-dateutil>=2.8.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from pandas) (2.8.2)\r\n",
       "Requirement already satisfied: pytz>=2020.1 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from pandas) (2022.6)\r\n",
       "Requirement already satisfied: sortedcontainers~=2.2 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from portion) (2.4.0)\r\n",
+      "Requirement already satisfied: et-xmlfile in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from openpyxl) (1.1.0)\r\n",
       "Requirement already satisfied: six>=1.5 in /home/lstreit/anaconda3/envs/hestia/lib/python3.11/site-packages (from python-dateutil>=2.8.1->pandas) (1.16.0)\r\n"
      ]
     }
    ],
    "source": [
-    "! pip install numpy pandas portion"
+    "! pip install numpy pandas portion openpyxl"
    ],
    "metadata": {
     "collapsed": false
@@ -54,14 +56,12 @@
    "execution_count": 2,
    "outputs": [],
    "source": [
-    "import datetime\n",
-    "import glob\n",
     "import os\n",
-    "from pathlib import Path\n",
-    "from typing import Callable, Optional, Tuple, Any\n",
+    "from typing import Callable, Any\n",
     "\n",
     "import numpy as np\n",
-    "import pandas as pd"
+    "\n",
+    "from utils import *"
    ],
    "metadata": {
     "collapsed": false
@@ -72,117 +72,7 @@
    "execution_count": 3,
    "outputs": [],
    "source": [
-    "class Table(pd.DataFrame):\n",
-    "    \"\"\"Some Python magic to be able to type hint things like\n",
-    "    df: Table['begin': datetime, 'end': datetime]\"\"\"\n",
-    "\n",
-    "    def __class_getitem__(cls, _):\n",
-    "        return list[str]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "outputs": [],
-   "source": [
-    "Timestamp = datetime.datetime"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "outputs": [],
-   "source": [
-    "PeriodTable = Table['begin': Timestamp, 'end': Timestamp]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "outputs": [],
-   "source": [
     "data_folder = Path(os.getcwd()) / 'data'"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "outputs": [],
-   "source": [
-    "def find_file(pattern: str, folder: Path) -> Path:\n",
-    "    \"\"\"\n",
-    "    Looks for a file matching the given pattern inside the given folder\n",
-    "    :param pattern: a glob file pattern\n",
-    "    :param folder: a path leading to a folder where the pattern should be applied\n",
-    "    :return: a path to the first file matching the pattern, or a value error if none.\n",
-    "    \"\"\"\n",
-    "    matches = glob.glob(pattern, root_dir=folder)\n",
-    "    if len(matches) == 0:\n",
-    "        raise ValueError(f'Could not find file {pattern} in {folder}')\n",
-    "    elif len(matches) > 1:\n",
-    "        print(f'Found many matches for {pattern} in {folder}. Using the first.')\n",
-    "    return folder / matches[0]"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "outputs": [],
-   "source": [
-    "def find_table(pattern: str, folder: Path, usecols: Optional[list[str]] = None) -> Table:\n",
-    "    \"\"\"\n",
-    "    Looks for a csv-like file whose name matches the pattern and is located inside folder, using only the specified columns.\n",
-    "    If found, reads it and assigns the file name as a column.\n",
-    "    :param pattern: a glob file pattern\n",
-    "    :param folder: a path leading to a folder where the pattern should be applied\n",
-    "    :param usecols: an optional list of columns present in the data file, only they will be loaded\n",
-    "    :return: a Table (a.k.a. pandas DataFrame) having the specified columns and the file name as a column.\n",
-    "    \"\"\"\n",
-    "    file = find_file(pattern, folder)\n",
-    "    table = pd.read_csv(file, usecols=usecols)\n",
-    "    if usecols is not None:\n",
-    "        table = table[usecols]\n",
-    "    return table.assign(file=file.name)"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "outputs": [],
-   "source": [
-    "def find_date_range(pattern: str, folder: Path, date_cols: list[str]) -> (Timestamp, Timestamp):\n",
-    "    \"\"\"\n",
-    "\n",
-    "    :param pattern: a glob file pattern\n",
-    "    :param folder: a path leading to a folder where the pattern should be applied\n",
-    "    :param date_cols: a list of column names that are dates\n",
-    "    :return: the minimum and maximum observed dates\n",
-    "    Usage:\n",
-    "    find_date_range('*Driver Trip Status.csv', data_folder / 'Brice' / 'raw' / 'SAR',\n",
-    "                    ['begin_timestamp_local', 'end_timestamp_local'])\n",
-    "    \"\"\"\n",
-    "    df = find_table(pattern, folder, usecols=date_cols)\n",
-    "    for c in date_cols:\n",
-    "        df[c] = pd.to_datetime(df[c])\n",
-    "    return df[date_cols].min().min(), df[date_cols].max().max()"
    ],
    "metadata": {
     "collapsed": false
@@ -191,38 +81,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "Currently unused code\n",
-    "\n",
-    "def df_to_interval(df: PeriodTable) -> P.interval:\n",
-    "    \"\"\"Converts a DataFrame with columns 'begin' and 'end' into a Portion interval, merging entries that overlap.\"\"\"\n",
-    "    return P.Interval(*[P.closed(row['begin'], row['end']) for row in df.to_dict('records')])\n",
-    "\n",
-    "\n",
-    "def interval_to_df(interval: P.interval) -> PeriodTable:\n",
-    "    \"\"\"Converts a Portion interval into a dataframe with columns 'begin' and 'end'.\"\"\"\n",
-    "    return pd.DataFrame([{'begin': begin, 'end': end} for _, begin, end, _ in P.to_data(interval)])\n",
-    "\n",
-    "def make_status_intervals(df: PeriodTable) -> dict[str, P.interval]:\n",
-    "    return {s: df_to_interval(df[df.status == s]) for s in df.status.unique()}\n",
-    "\n",
-    "def interval_merge_logic(lt: dict[str, P.interval], oo: dict[str, P.interval]) -> dict[str, P.interval]:\n",
-    "    P3 = lt['P3'] | oo['P3']\n",
-    "    P2 = (lt['P2'] | oo['P2']) - P3\n",
-    "    P1 = oo['P1'] - (P2 | P3)\n",
-    "    return {'P1': P1, 'P2': P2, 'P3': P3}\n",
-    "\n",
-    "def main_interval_logic(lt: dict[str, P.interval], oo: dict[str, P.interval], P0_has_priority=False) -> Table:\n",
-    "    \"\"\"Consider the following ordering of priorities: P3 > P2 > P1. P0_has_priority determines if P0 is on the left or right of inequalities.\"\"\"\n",
-    "    if P0_has_priority:\n",
-    "        for d in [lt, oo]:\n",
-    "            for k in d.keys():\n",
-    "                if k != 'P0':\n",
-    "                    d[k] = d[k] - oo['P0']\n",
-    "    lt['P2'] = lt['P2'] - lt['P3']\n",
-    "    oo['P2'] = oo['P2'] - oo['P3']\n",
-    "    oo['P1'] = oo['P1'] - (oo['P2'] | oo['P3'])\n",
-    "    intervals = interval_merge_logic(lt, oo)\n",
-    "    return pd.concat([interval_to_df(i).assign(status=f'{s} consistent') for s, i in intervals.items()])"
+    "### Pipeline steps"
    ],
    "metadata": {
     "collapsed": false
@@ -230,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "outputs": [],
    "source": [
     "def time_tuples_to_periods(\n",
@@ -271,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "outputs": [],
    "source": [
     "def merge_overlapping_intervals(table: PeriodTable, agg_dict: Optional[dict] = None) -> PeriodTable:\n",
@@ -308,11 +167,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "outputs": [],
    "source": [
-    "def mile2km(n_miles: float) -> float:\n",
-    "    return n_miles * 1.609344"
+    "def split_hours(table: PeriodTable) -> PeriodTable:\n",
+    "    \"\"\"\n",
+    "    Splits intervals spanning many hours periods in as many intervals as hours covered by the interval.\n",
+    "    If the interval is associated to numerical values (like distance or money), these values are\n",
+    "    transferred to the new intervals but are weighted according to the new intervals' duration.\n",
+    "    :param table: the table whose intervals should be split\n",
+    "    :return: a table with no intervals spanning over AM and PM\n",
+    "    \"\"\"\n",
+    "\n",
+    "    def rec(begin: Timestamp, end: Timestamp, **rest) -> list[dict]:\n",
+    "        og_duration = end - begin\n",
+    "        # Check if the interval spans many days, and split into as many days as it spans\n",
+    "        if begin.hour != end.hour:\n",
+    "            rows = [scaled_interval(begin, begin.replace(minute=59, second=59), rest, og_duration)]\n",
+    "            for hours in range(end.hour - begin.hour - 1):\n",
+    "                mid = begin + datetime.timedelta(hours=hours)\n",
+    "                rows.append(scaled_interval(mid.replace(minute=0, second=0),\n",
+    "                                            mid.replace(minute=59, second=59), rest, og_duration))\n",
+    "            rows.append(scaled_interval(end.replace(minute=0, second=0), end, rest, og_duration))\n",
+    "            return rows\n",
+    "        return [{'begin': begin, 'end': end, **rest}]\n",
+    "\n",
+    "    return pd.DataFrame([e for d in table.to_dict('records') for e in rec(**d)])"
    ],
    "metadata": {
     "collapsed": false
@@ -329,7 +209,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "outputs": [],
    "source": [
     "def load_lifetime_trips(folder: Path, pattern: str = '*Driver Lifetime Trips.csv') -> PeriodTable:\n",
@@ -358,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "outputs": [],
    "source": [
     "def load_on_off(folder: Path, pattern: str = '*Driver Online Offline.csv') -> PeriodTable:\n",
@@ -378,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 9,
    "outputs": [],
    "source": [
     "def load_dispatches(folder: Path, pattern: str = 'TODO') -> Table:\n",
@@ -395,7 +275,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 10,
    "outputs": [],
    "source": [
     "def load_trip_status(folder: Path, pattern: str = '*Driver Trip Status.csv') -> PeriodTable:\n",
@@ -410,18 +290,8 @@
    }
   },
   {
-   "cell_type": "markdown",
-   "source": [
-    "def load_distance_traveled(folder: Path, pattern: str = 'TODO') -> pd.DataFrame:\n",
-    "    pass  # TODO"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 11,
    "outputs": [],
    "source": [
     "def load_sar(folder: Path) -> Table:\n",
@@ -444,7 +314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 12,
    "outputs": [],
    "source": [
     "def load_portal(folder: Path):\n",
@@ -475,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 13,
    "outputs": [],
    "source": [
     "def guillaume_filtering_logic(\n",
@@ -494,9 +364,6 @@
     "                (filtered.datetime.dt.year == row.year) & (filtered.datetime.dt.month == row.month),\n",
     "                daily[c] * row['Uber'], daily[c])\n",
     "\n",
-    "    def date_range(from_date: Tuple[int, ...], to_date: Tuple[int, ...]) -> list[datetime.date]:\n",
-    "        return pd.date_range(datetime.date(*from_date), datetime.date(*to_date)).values\n",
-    "\n",
     "    # Second, remove all morning weekday entries when Guillaume was working for IMAD, except for the specific dates below\n",
     "    dates_to_keep = [datetime.date(2020, 11, 26), *date_range((2020, 12, 21), (2020, 12, 25)),\n",
     "                     *date_range((2021, 2, 1), (2021, 2, 12)), *date_range((2021, 8, 16), (2021, 8, 28)),\n",
@@ -513,118 +380,6 @@
    }
   },
   {
-   "cell_type": "code",
-   "execution_count": 20,
-   "outputs": [],
-   "source": [
-    "def split_AM_PM(table: PeriodTable) -> PeriodTable:\n",
-    "    \"\"\"\n",
-    "    Splits intervals spanning many days or many morning/afternoon periods in two.\n",
-    "    If the interval is associated to numerical values (like distance or money), these values are\n",
-    "    transferred to the new intervals but are weighted according to the new intervals' duration.\n",
-    "    :param table: the table whose intervals should be split\n",
-    "    :return: a table with no intervals spanning over AM and PM\n",
-    "    \"\"\"\n",
-    "\n",
-    "    def scaled_interval(begin: Timestamp, end: Timestamp, attributes: dict, og_duration) -> dict:\n",
-    "        \"\"\"Creates an interval (a dict with begin, end and other attributes) given the original attributes and the original \"\"\"\n",
-    "        return {'begin': begin, 'end': end,\n",
-    "                **{k: v * (end - begin) / og_duration if isinstance(v, float) else v for k, v in attributes.items()}}\n",
-    "\n",
-    "    def rec(begin: Timestamp, end: Timestamp, **rest) -> list[dict]:\n",
-    "        og_duration = end - begin\n",
-    "        # Check if the interval spans many days, and split into as many days as it spans\n",
-    "        if begin.day != end.day:\n",
-    "            rows = [scaled_interval(begin, begin.replace(hour=23, minute=59, second=59), rest, og_duration)]\n",
-    "            for days in range(end.day - begin.day - 1):\n",
-    "                mid = begin + datetime.timedelta(days=days)\n",
-    "                rows.append(scaled_interval(mid.replace(hour=0, minute=0, second=0),\n",
-    "                                            mid.replace(hour=23, minute=59, second=59), rest, og_duration))\n",
-    "            rows.append(scaled_interval(end.replace(hour=0, minute=0, second=0), end, rest, og_duration))\n",
-    "            # Call itself recursively to split resulting days into AM/PM\n",
-    "            return [e for r in rows for e in rec(**r)]\n",
-    "        # Check if the interval spans many AM/PM periods\n",
-    "        elif begin.hour < 12 <= end.hour:\n",
-    "            return [scaled_interval(begin, end.replace(hour=11, minute=59, second=59), rest, og_duration),\n",
-    "                    scaled_interval(end.replace(hour=12, minute=0, second=0), end, rest, og_duration)]\n",
-    "        else:\n",
-    "            return [{'begin': begin, 'end': end, **rest}]\n",
-    "\n",
-    "    return pd.DataFrame([e for d in table.to_dict('records') for e in rec(**d)])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 21,
-   "outputs": [],
-   "source": [
-    "def split_hours(table: PeriodTable) -> PeriodTable:\n",
-    "    \"\"\"\n",
-    "    Splits intervals spanning many hours periods in as many intervals as hours covered by the interval.\n",
-    "    If the interval is associated to numerical values (like distance or money), these values are\n",
-    "    transferred to the new intervals but are weighted according to the new intervals' duration.\n",
-    "    :param table: the table whose intervals should be split\n",
-    "    :return: a table with no intervals spanning over AM and PM\n",
-    "    \"\"\"\n",
-    "\n",
-    "    def scaled_interval(begin: Timestamp, end: Timestamp, attributes: dict, og_duration) -> dict:\n",
-    "        \"\"\"Creates an interval (a dict with begin, end and other attributes) given the original attributes and the original \"\"\"\n",
-    "        return {'begin': begin, 'end': end,\n",
-    "                **{k: v * (end - begin) / og_duration if isinstance(v, float) else v for k, v in attributes.items()}}\n",
-    "\n",
-    "    def rec(begin: Timestamp, end: Timestamp, **rest) -> list[dict]:\n",
-    "        og_duration = end - begin\n",
-    "        # Check if the interval spans many days, and split into as many days as it spans\n",
-    "        if begin.hour != end.hour:\n",
-    "            rows = [scaled_interval(begin, begin.replace(minute=59, second=59), rest, og_duration)]\n",
-    "            for hours in range(end.hour - begin.hour - 1):\n",
-    "                mid = begin + datetime.timedelta(hours=hours)\n",
-    "                rows.append(scaled_interval(mid.replace(minute=0, second=0),\n",
-    "                                            mid.replace(minute=59, second=59), rest, og_duration))\n",
-    "            rows.append(scaled_interval(end.replace(minute=0, second=0), end, rest, og_duration))\n",
-    "            return rows\n",
-    "        return [{'begin': begin, 'end': end, **rest}]\n",
-    "\n",
-    "    return pd.DataFrame([e for d in table.to_dict('records') for e in rec(**d)])"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 22,
-   "outputs": [],
-   "source": [
-    "def find_week_limits(date: Timestamp) -> str:\n",
-    "    week_start = date - datetime.timedelta(days=date.weekday())\n",
-    "    week_end = week_start + datetime.timedelta(days=6)\n",
-    "    return f'{week_start.date()} to {week_end.date()}'.replace('-', '/').replace('to', '-')"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "outputs": [],
-   "source": [
-    "def select(d: dict[str], keep: Optional[list[str]] = None, drop: Optional[list[str]] = None) -> dict[str]:\n",
-    "    assert (keep is None) != (drop is None), 'Only one of keep or drop can be specified'\n",
-    "    if keep is not None:\n",
-    "        return {k: v for k, v in d.items() if k in keep}\n",
-    "    if drop is not None:\n",
-    "        return {k: v for k, v in d.items() if k not in drop}"
-   ],
-   "metadata": {
-    "collapsed": false
-   }
-  },
-  {
    "cell_type": "markdown",
    "source": [
     "### Running the pipeline"
@@ -635,7 +390,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 14,
    "outputs": [],
    "source": [
     "all_facets = ['duration_h', 'distance_km', 'uber_paid']\n",
@@ -660,9 +415,9 @@
     "        time_properties: Optional[dict[str, Callable[[Timestamp], Any]]] = None,\n",
     "        name: str = 'analysis',\n",
     "        facets: list[str] = all_facets,\n",
-    "        save_at: Path = data_folder / 'results',\n",
+    "        save_folder: Path = data_folder / 'results',\n",
     "        compute_most_lucrative_months: bool = True,\n",
-    ") -> Tuple[pd.DataFrame, ...]:\n",
+    ") -> dict[str, Table]:\n",
     "    # Apply interval logic if specified\n",
     "    if interval_logic is not None:\n",
     "        periods = interval_logic(periods)\n",
@@ -699,38 +454,37 @@
     "    periods['month'] = periods.end.apply(lambda d: f'{d.month:02d}. {d.month_name()}')\n",
     "    periods['year'] = periods.end.dt.year\n",
     "\n",
-    "    hourly = periods.groupby(['date', 'hour']).agg(agg_dict).reset_index()\n",
-    "    daily = periods.groupby(['date', 'year', 'month', 'week']).agg(agg_dict).reset_index()\n",
+    "    tabs = {'periods': periods,\n",
+    "            'hourly': periods.groupby(['date', 'hour']).agg(agg_dict).reset_index(),\n",
+    "            'daily': periods.groupby(['date', 'year', 'month', 'week']).agg(agg_dict).reset_index()}\n",
     "\n",
     "    # Filter the data if a filtering function is specified\n",
     "    if filtering_logic is not None:\n",
-    "        filtered = filtering_logic(daily)\n",
-    "        daily = pd.concat([daily, filtered], axis=1)\n",
+    "        filtered = filtering_logic(tabs['daily'])\n",
+    "        tabs['daily'] = pd.concat([tabs['daily'], filtered], axis=1)\n",
     "        agg_dict = {**agg_dict, **{c: 'sum' for c in filtered.columns}}\n",
     "\n",
-    "    weekly = daily.groupby(['week']).agg(agg_dict).reset_index()\n",
-    "    monthly = daily.groupby(['year', 'month']).agg(agg_dict).reset_index()\n",
-    "    yearly = daily.groupby(['year']).agg(agg_dict).reset_index()\n",
-    "    total = yearly.agg(agg_dict).to_frame().T\n",
+    "    tabs['weekly'] = tabs['daily'].groupby(['week']).agg(agg_dict).reset_index()\n",
+    "    tabs['monthly'] = tabs['daily'].groupby(['year', 'month']).agg(agg_dict).reset_index()\n",
+    "    tabs['yearly'] = tabs['daily'].groupby(['year']).agg(agg_dict).reset_index()\n",
+    "    tabs['total'] = tabs['yearly'].agg(agg_dict).to_frame().T\n",
     "\n",
     "    if compute_most_lucrative_months:\n",
-    "        most_lucrative_months: Table = monthly.copy()\n",
-    "        most_lucrative_months['uber_paid_total'] = monthly[[c for c in monthly.columns if 'uber_paid' in c]].sum(axis=1)\n",
-    "        most_lucrative_months.sort_values('uber_paid_total', ascending=False, inplace=True)\n",
-    "        most_lucrative_months.to_csv(save_at / f'{name}_4_bis_most_lucrative_months.csv', index=False,\n",
-    "                                     float_format='%.2f')\n",
+    "        df = tabs['monthly'].copy()\n",
+    "        df['uber_paid_total'] = tabs['monthly'][[c for c in tabs['monthly'].columns if 'uber_paid' in c]].sum(axis=1)\n",
+    "        df = df.sort_values('uber_paid_total', ascending=False)\n",
+    "        tabs['most_lucrative_months'] = df\n",
+    "        request_months = list(df.iloc[:10].sort_values(['year', 'month']).apply(\n",
+    "            lambda r: f'{french_months[int(r.month.split(\".\")[0])]} {r.year}', axis=1))\n",
+    "        request_months += list(\n",
+    "            filter(lambda s: s not in request_months, [f'{french_months[i]} 2020' for i in range(3, 12 + 1)]))\n",
+    "        with open(save_folder / 'sar_request_text.txt', 'w') as f:\n",
+    "            f.write(sar_text.replace('{REPLACE_HERE}', ', '.join(request_months)))\n",
     "\n",
-    "    # Writing tables to disk\n",
-    "    save_at.mkdir(parents=True, exist_ok=True)\n",
-    "    periods.to_csv(save_at / f'{name}_0_periods.csv', index=False, float_format='%.2f')\n",
-    "    hourly.to_csv(save_at / f'{name}_1_hourly.csv', index=False, float_format='%.2f')\n",
-    "    daily.to_csv(save_at / f'{name}_2_daily.csv', index=False, float_format='%.2f')\n",
-    "    weekly.to_csv(save_at / f'{name}_3_weekly.csv', index=False, float_format='%.2f')\n",
-    "    monthly.to_csv(save_at / f'{name}_4_monthly.csv', index=False, float_format='%.2f')\n",
-    "    yearly.to_csv(save_at / f'{name}_5_yearly.csv', index=False, float_format='%.2f')\n",
-    "    total.to_csv(save_at / f'{name}_6_total.csv', index=False, float_format='%.2f')\n",
+    "    save_folder.mkdir(parents=True, exist_ok=True)\n",
+    "    save_excel(save_folder / f'{name}_results.xlsx', tabs, index=False, float_format='%.2f')\n",
     "\n",
-    "    return hourly, daily, weekly, yearly, total"
+    "    return tabs"
    ],
    "metadata": {
     "collapsed": false
@@ -756,7 +510,7 @@
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
     "             filtering_logic=guillaume_filtering_logic,\n",
     "             name='sar', time_properties=select(all_time_properties, keep=['time_of_day', 'day_type']),\n",
-    "             save_at=data_folder / 'Guillaume' / 'results')"
+    "             save_folder=data_folder / 'Guillaume' / 'results')"
    ],
    "metadata": {
     "collapsed": false
@@ -764,13 +518,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Kidane' / 'raw' / 'SAR'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
     "             name='sar', time_properties=all_time_properties,\n",
-    "             save_at=data_folder / 'Kidane' / 'results')"
+    "             save_folder=data_folder / 'Kidane' / 'results')"
    ],
    "metadata": {
     "collapsed": false
@@ -778,35 +532,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
-   "outputs": [
-    {
-     "ename": "ValueError",
-     "evalue": "Index contains duplicate entries, cannot reshape",
-     "output_type": "error",
-     "traceback": [
-      "\u001B[0;31m---------------------------------------------------------------------------\u001B[0m",
-      "\u001B[0;31mValueError\u001B[0m                                Traceback (most recent call last)",
-      "Cell \u001B[0;32mIn[28], line 1\u001B[0m\n\u001B[0;32m----> 1\u001B[0m _ \u001B[38;5;241m=\u001B[39m \u001B[43mpipeline\u001B[49m\u001B[43m(\u001B[49m\u001B[43mload_sar\u001B[49m\u001B[43m(\u001B[49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mraw\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mSAR\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      2\u001B[0m \u001B[43m             \u001B[49m\u001B[43minterval_logic\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;28;43;01mlambda\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mt\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[43mmerge_overlapping_intervals\u001B[49m\u001B[43m(\u001B[49m\u001B[43mt\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43m{\u001B[49m\u001B[43mc\u001B[49m\u001B[43m:\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msum\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;28;43;01mfor\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43mc\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;129;43;01min\u001B[39;49;00m\u001B[43m \u001B[49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43muber_paid\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mdistance_km\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m}\u001B[49m\u001B[43m)\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      3\u001B[0m \u001B[43m             \u001B[49m\u001B[43mname\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43msar\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mtime_properties\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mall_time_properties\u001B[49m\u001B[43m,\u001B[49m\n\u001B[1;32m      4\u001B[0m \u001B[43m             \u001B[49m\u001B[43msave_at\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mdata_folder\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mBrice\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;241;43m/\u001B[39;49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mresults\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m)\u001B[49m\n",
-      "Cell \u001B[0;32mIn[25], line 21\u001B[0m, in \u001B[0;36mpipeline\u001B[0;34m(periods, interval_logic, filtering_logic, time_properties, name, facets, save_at, compute_monthly_top_10)\u001B[0m\n\u001B[1;32m     18\u001B[0m periods \u001B[38;5;241m=\u001B[39m split_hours(periods)\n\u001B[1;32m     20\u001B[0m \u001B[38;5;66;03m# Pivot table so that each there is a single line per interval and per granularity of interest\u001B[39;00m\n\u001B[0;32m---> 21\u001B[0m periods \u001B[38;5;241m=\u001B[39m \u001B[43mperiods\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mbegin\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mend\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43m[\u001B[49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[38;5;124;43mstatus\u001B[39;49m\u001B[38;5;124;43m'\u001B[39;49m\u001B[43m]\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfacets\u001B[49m\u001B[43m)\u001B[49m\u001B[38;5;241m.\u001B[39mreset_index()\n\u001B[1;32m     22\u001B[0m periods[periods \u001B[38;5;241m==\u001B[39m \u001B[38;5;241m0\u001B[39m] \u001B[38;5;241m=\u001B[39m np\u001B[38;5;241m.\u001B[39mnan\n\u001B[1;32m     23\u001B[0m periods\u001B[38;5;241m.\u001B[39mdrop(columns\u001B[38;5;241m=\u001B[39mperiods\u001B[38;5;241m.\u001B[39mcolumns[periods\u001B[38;5;241m.\u001B[39misna()\u001B[38;5;241m.\u001B[39mall()],\n\u001B[1;32m     24\u001B[0m              inplace\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mTrue\u001B[39;00m)  \u001B[38;5;66;03m# this and previous remove columns that have only 0/nans\u001B[39;00m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/util/_decorators.py:331\u001B[0m, in \u001B[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001B[0;34m(*args, **kwargs)\u001B[0m\n\u001B[1;32m    325\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28mlen\u001B[39m(args) \u001B[38;5;241m>\u001B[39m num_allow_args:\n\u001B[1;32m    326\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    327\u001B[0m         msg\u001B[38;5;241m.\u001B[39mformat(arguments\u001B[38;5;241m=\u001B[39m_format_argument_list(allow_args)),\n\u001B[1;32m    328\u001B[0m         \u001B[38;5;167;01mFutureWarning\u001B[39;00m,\n\u001B[1;32m    329\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    330\u001B[0m     )\n\u001B[0;32m--> 331\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mfunc\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43margs\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/frame.py:8564\u001B[0m, in \u001B[0;36mDataFrame.pivot\u001B[0;34m(self, index, columns, values)\u001B[0m\n\u001B[1;32m   8558\u001B[0m \u001B[38;5;129m@Substitution\u001B[39m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m   8559\u001B[0m \u001B[38;5;129m@Appender\u001B[39m(_shared_docs[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mpivot\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   8560\u001B[0m \u001B[38;5;129m@deprecate_nonkeyword_arguments\u001B[39m(version\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, allowed_args\u001B[38;5;241m=\u001B[39m[\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mself\u001B[39m\u001B[38;5;124m\"\u001B[39m])\n\u001B[1;32m   8561\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21mpivot\u001B[39m(\u001B[38;5;28mself\u001B[39m, index\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, columns\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m, values\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m) \u001B[38;5;241m-\u001B[39m\u001B[38;5;241m>\u001B[39m DataFrame:\n\u001B[1;32m   8562\u001B[0m     \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mpivot\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m pivot\n\u001B[0;32m-> 8564\u001B[0m     \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mpivot\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mindex\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mcolumns\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mcolumns\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mvalues\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mvalues\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/util/_decorators.py:331\u001B[0m, in \u001B[0;36mdeprecate_nonkeyword_arguments.<locals>.decorate.<locals>.wrapper\u001B[0;34m(*args, **kwargs)\u001B[0m\n\u001B[1;32m    325\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28mlen\u001B[39m(args) \u001B[38;5;241m>\u001B[39m num_allow_args:\n\u001B[1;32m    326\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    327\u001B[0m         msg\u001B[38;5;241m.\u001B[39mformat(arguments\u001B[38;5;241m=\u001B[39m_format_argument_list(allow_args)),\n\u001B[1;32m    328\u001B[0m         \u001B[38;5;167;01mFutureWarning\u001B[39;00m,\n\u001B[1;32m    329\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    330\u001B[0m     )\n\u001B[0;32m--> 331\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mfunc\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43margs\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[38;5;241;43m*\u001B[39;49m\u001B[43mkwargs\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/pivot.py:540\u001B[0m, in \u001B[0;36mpivot\u001B[0;34m(data, index, columns, values)\u001B[0m\n\u001B[1;32m    536\u001B[0m         indexed \u001B[38;5;241m=\u001B[39m data\u001B[38;5;241m.\u001B[39m_constructor_sliced(data[values]\u001B[38;5;241m.\u001B[39m_values, index\u001B[38;5;241m=\u001B[39mmultiindex)\n\u001B[1;32m    537\u001B[0m \u001B[38;5;66;03m# error: Argument 1 to \"unstack\" of \"DataFrame\" has incompatible type \"Union\u001B[39;00m\n\u001B[1;32m    538\u001B[0m \u001B[38;5;66;03m# [List[Any], ExtensionArray, ndarray[Any, Any], Index, Series]\"; expected\u001B[39;00m\n\u001B[1;32m    539\u001B[0m \u001B[38;5;66;03m# \"Hashable\"\u001B[39;00m\n\u001B[0;32m--> 540\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43mindexed\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[43mcolumns_listlike\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/frame.py:9109\u001B[0m, in \u001B[0;36mDataFrame.unstack\u001B[0;34m(self, level, fill_value)\u001B[0m\n\u001B[1;32m   9047\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   9048\u001B[0m \u001B[38;5;124;03mPivot a level of the (necessarily hierarchical) index labels.\u001B[39;00m\n\u001B[1;32m   9049\u001B[0m \n\u001B[0;32m   (...)\u001B[0m\n\u001B[1;32m   9105\u001B[0m \u001B[38;5;124;03mdtype: float64\u001B[39;00m\n\u001B[1;32m   9106\u001B[0m \u001B[38;5;124;03m\"\"\"\u001B[39;00m\n\u001B[1;32m   9107\u001B[0m \u001B[38;5;28;01mfrom\u001B[39;00m \u001B[38;5;21;01mpandas\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mcore\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m\u001B[38;5;21;01m.\u001B[39;00m\u001B[38;5;21;01mreshape\u001B[39;00m \u001B[38;5;28;01mimport\u001B[39;00m unstack\n\u001B[0;32m-> 9109\u001B[0m result \u001B[38;5;241m=\u001B[39m \u001B[43munstack\u001B[49m\u001B[43m(\u001B[49m\u001B[38;5;28;43mself\u001B[39;49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m   9111\u001B[0m \u001B[38;5;28;01mreturn\u001B[39;00m result\u001B[38;5;241m.\u001B[39m__finalize__(\u001B[38;5;28mself\u001B[39m, method\u001B[38;5;241m=\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124munstack\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:476\u001B[0m, in \u001B[0;36munstack\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    474\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj, DataFrame):\n\u001B[1;32m    475\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex):\n\u001B[0;32m--> 476\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m \u001B[43m_unstack_frame\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mfill_value\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mfill_value\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    477\u001B[0m     \u001B[38;5;28;01melse\u001B[39;00m:\n\u001B[1;32m    478\u001B[0m         \u001B[38;5;28;01mreturn\u001B[39;00m obj\u001B[38;5;241m.\u001B[39mT\u001B[38;5;241m.\u001B[39mstack(dropna\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mFalse\u001B[39;00m)\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:499\u001B[0m, in \u001B[0;36m_unstack_frame\u001B[0;34m(obj, level, fill_value)\u001B[0m\n\u001B[1;32m    497\u001B[0m \u001B[38;5;28;01mdef\u001B[39;00m \u001B[38;5;21m_unstack_frame\u001B[39m(obj: DataFrame, level, fill_value\u001B[38;5;241m=\u001B[39m\u001B[38;5;28;01mNone\u001B[39;00m):\n\u001B[1;32m    498\u001B[0m     \u001B[38;5;28;01massert\u001B[39;00m \u001B[38;5;28misinstance\u001B[39m(obj\u001B[38;5;241m.\u001B[39mindex, MultiIndex)  \u001B[38;5;66;03m# checked by caller\u001B[39;00m\n\u001B[0;32m--> 499\u001B[0m     unstacker \u001B[38;5;241m=\u001B[39m \u001B[43m_Unstacker\u001B[49m\u001B[43m(\u001B[49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43mindex\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mlevel\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mlevel\u001B[49m\u001B[43m,\u001B[49m\u001B[43m \u001B[49m\u001B[43mconstructor\u001B[49m\u001B[38;5;241;43m=\u001B[39;49m\u001B[43mobj\u001B[49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_constructor\u001B[49m\u001B[43m)\u001B[49m\n\u001B[1;32m    501\u001B[0m     \u001B[38;5;28;01mif\u001B[39;00m \u001B[38;5;129;01mnot\u001B[39;00m obj\u001B[38;5;241m.\u001B[39m_can_fast_transpose:\n\u001B[1;32m    502\u001B[0m         mgr \u001B[38;5;241m=\u001B[39m obj\u001B[38;5;241m.\u001B[39m_mgr\u001B[38;5;241m.\u001B[39munstack(unstacker, fill_value\u001B[38;5;241m=\u001B[39mfill_value)\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:137\u001B[0m, in \u001B[0;36m_Unstacker.__init__\u001B[0;34m(self, index, level, constructor)\u001B[0m\n\u001B[1;32m    129\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m num_cells \u001B[38;5;241m>\u001B[39m np\u001B[38;5;241m.\u001B[39miinfo(np\u001B[38;5;241m.\u001B[39mint32)\u001B[38;5;241m.\u001B[39mmax:\n\u001B[1;32m    130\u001B[0m     warnings\u001B[38;5;241m.\u001B[39mwarn(\n\u001B[1;32m    131\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mThe following operation may generate \u001B[39m\u001B[38;5;132;01m{\u001B[39;00mnum_cells\u001B[38;5;132;01m}\u001B[39;00m\u001B[38;5;124m cells \u001B[39m\u001B[38;5;124m\"\u001B[39m\n\u001B[1;32m    132\u001B[0m         \u001B[38;5;124mf\u001B[39m\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124min the resulting pandas object.\u001B[39m\u001B[38;5;124m\"\u001B[39m,\n\u001B[1;32m    133\u001B[0m         PerformanceWarning,\n\u001B[1;32m    134\u001B[0m         stacklevel\u001B[38;5;241m=\u001B[39mfind_stack_level(),\n\u001B[1;32m    135\u001B[0m     )\n\u001B[0;32m--> 137\u001B[0m \u001B[38;5;28;43mself\u001B[39;49m\u001B[38;5;241;43m.\u001B[39;49m\u001B[43m_make_selectors\u001B[49m\u001B[43m(\u001B[49m\u001B[43m)\u001B[49m\n",
-      "File \u001B[0;32m~/anaconda3/envs/hestia/lib/python3.11/site-packages/pandas/core/reshape/reshape.py:189\u001B[0m, in \u001B[0;36m_Unstacker._make_selectors\u001B[0;34m(self)\u001B[0m\n\u001B[1;32m    186\u001B[0m mask\u001B[38;5;241m.\u001B[39mput(selector, \u001B[38;5;28;01mTrue\u001B[39;00m)\n\u001B[1;32m    188\u001B[0m \u001B[38;5;28;01mif\u001B[39;00m mask\u001B[38;5;241m.\u001B[39msum() \u001B[38;5;241m<\u001B[39m \u001B[38;5;28mlen\u001B[39m(\u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mindex):\n\u001B[0;32m--> 189\u001B[0m     \u001B[38;5;28;01mraise\u001B[39;00m \u001B[38;5;167;01mValueError\u001B[39;00m(\u001B[38;5;124m\"\u001B[39m\u001B[38;5;124mIndex contains duplicate entries, cannot reshape\u001B[39m\u001B[38;5;124m\"\u001B[39m)\n\u001B[1;32m    191\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mgroup_index \u001B[38;5;241m=\u001B[39m comp_index\n\u001B[1;32m    192\u001B[0m \u001B[38;5;28mself\u001B[39m\u001B[38;5;241m.\u001B[39mmask \u001B[38;5;241m=\u001B[39m mask\n",
-      "\u001B[0;31mValueError\u001B[0m: Index contains duplicate entries, cannot reshape"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "outputs": [],
    "source": [
     "_ = pipeline(load_sar(data_folder / 'Brice' / 'raw' / 'SAR'),\n",
     "             interval_logic=lambda t: merge_overlapping_intervals(t, {c: 'sum' for c in ['uber_paid', 'distance_km']}),\n",
     "             name='sar', time_properties=all_time_properties,\n",
-    "             save_at=data_folder / 'Brice' / 'results')"
+    "             save_folder=data_folder / 'Brice' / 'results')"
    ],
    "metadata": {
     "collapsed": false
@@ -823,13 +555,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Guillaume' / 'raw' / 'Portal' / 'Driver'),\n",
     "             name='portal', time_properties=all_time_properties,\n",
     "             filtering_logic=guillaume_filtering_logic,\n",
-    "             save_at=data_folder / 'Guillaume' / 'results')"
+    "             save_folder=data_folder / 'Guillaume' / 'results')"
    ],
    "metadata": {
     "collapsed": false
@@ -837,12 +569,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "outputs": [],
    "source": [
     "_ = pipeline(load_portal(data_folder / 'Aria' / 'raw' / 'Portal' / 'Driver'),\n",
     "             name='portal', time_properties=select(all_time_properties, keep=['night', 'day_type']),\n",
-    "             save_at=data_folder / 'Aria' / 'results')"
+    "             save_folder=data_folder / 'Aria' / 'results')"
    ],
    "metadata": {
     "collapsed": false

--- a/custom_types.py
+++ b/custom_types.py
@@ -1,0 +1,16 @@
+import datetime
+
+import pandas as pd
+
+Timestamp = datetime.datetime
+
+
+class Table(pd.DataFrame):
+    """Some Python magic to be able to type hint things like
+    df: Table['begin': datetime, 'end': datetime]"""
+
+    def __class_getitem__(cls, _):
+        return list[str]
+
+
+PeriodTable = Table['begin': Timestamp, 'end': Timestamp]

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,216 @@
+import glob
+from pathlib import Path
+from typing import Optional, Tuple
+from custom_types import *
+
+import pandas as pd
+import portion as P
+
+
+def find_file(pattern: str, folder: Path) -> Path:
+    """
+    Looks for a file matching the given pattern inside the given folder
+    :param pattern: a glob file pattern
+    :param folder: a path leading to a folder where the pattern should be applied
+    :return: a path to the first file matching the pattern, or a value error if none.
+    """
+    matches = glob.glob(pattern, root_dir=folder)
+    if len(matches) == 0:
+        raise ValueError(f'Could not find file {pattern} in {folder}')
+    elif len(matches) > 1:
+        print(f'Found many matches for {pattern} in {folder}. Using the first.')
+    return folder / matches[0]
+
+
+def find_table(pattern: str, folder: Path, usecols: Optional[list[str]] = None) -> Table['file': str]:
+    """
+    Looks inside folder for a csv-like file whose name matches the pattern, and only reads the specified columns.
+    If found, reads it and assigns the file name as a column.
+    :param pattern: a glob file pattern
+    :param folder: a path leading to a folder where the pattern should be applied
+    :param usecols: an optional list of columns present in the data file, only they will be loaded
+    :return: a Table (a.k.a. pandas DataFrame) having the specified columns and the file name as a column.
+    """
+    file = find_file(pattern, folder)
+    table = pd.read_csv(file, usecols=usecols)
+    if usecols is not None:
+        table = table[usecols]
+    return table.assign(file=file.name)
+
+
+def find_date_range(pattern: str, folder: Path, date_cols: list[str]) -> (Timestamp, Timestamp):
+    """
+
+    :param pattern: a glob file pattern
+    :param folder: a path leading to a folder where the pattern should be applied
+    :param date_cols: a list of column names that are dates
+    :return: the minimum and maximum observed dates
+    Usage:
+    find_date_range('*Driver Trip Status.csv', data_folder / 'Brice' / 'raw' / 'SAR',
+                    ['begin_timestamp_local', 'end_timestamp_local'])
+    """
+    df = find_table(pattern, folder, usecols=date_cols)
+    for c in date_cols:
+        df[c] = pd.to_datetime(df[c])
+    return df[date_cols].min().min(), df[date_cols].max().max()
+
+
+def date_range(from_date: Tuple[int, ...], to_date: Tuple[int, ...]) -> list[datetime.date]:
+    return list(pd.date_range(datetime.date(*from_date), datetime.date(*to_date)).values)
+
+
+def scaled_interval(begin: Timestamp, end: Timestamp, attributes: dict, og_duration) -> dict:
+    """Creates an interval (a dict with begin, end and other keys) given the original attributes and the original """
+    return {'begin': begin, 'end': end,
+            **{k: v * (end - begin) / og_duration if isinstance(v, float) else v for k, v in attributes.items()}}
+
+
+def save_excel(filename: str | Path, sheets: dict[str, pd.DataFrame], **kwargs):
+    """"""
+    with pd.ExcelWriter(filename) as writer:
+        for name, sheet in sheets.items():
+            sheet.to_excel(writer, sheet_name=name, **kwargs)
+
+
+def select(d: dict[str], keep: Optional[list[str]] = None, drop: Optional[list[str]] = None) -> dict[str]:
+    assert (keep is None) != (drop is None), 'Only one of keep or drop can be specified'
+    if keep is not None:
+        return {k: v for k, v in d.items() if k in keep}
+    if drop is not None:
+        return {k: v for k, v in d.items() if k not in drop}
+
+
+def find_week_limits(date: Timestamp) -> str:
+    week_start = date - datetime.timedelta(days=date.weekday())
+    week_end = week_start + datetime.timedelta(days=6)
+    return f'{week_start.date()} to {week_end.date()}'.replace('-', '/').replace('to', '-')
+
+
+def mile2km(n_miles: float) -> float:
+    return n_miles * 1.609344
+
+
+def df_to_interval(df: PeriodTable) -> P.interval:
+    """Converts a DataFrame with columns 'begin' and 'end' into a Portion interval, merging entries that overlap."""
+    return P.Interval(*[P.closed(row['begin'], row['end']) for row in df.to_dict('records')])
+
+
+def interval_to_df(interval: P.interval) -> PeriodTable:
+    """Converts a Portion interval into a dataframe with columns 'begin' and 'end'."""
+    return pd.DataFrame([{'begin': begin, 'end': end} for _, begin, end, _ in P.to_data(interval)])
+
+
+def make_status_intervals(df: PeriodTable) -> dict[str, P.interval]:
+    return {s: df_to_interval(df[df.status == s]) for s in df.status.unique()}
+
+
+def interval_merge_logic(lt: dict[str, P.interval], oo: dict[str, P.interval]) -> dict[str, P.interval]:
+    P3 = lt['P3'] | oo['P3']
+    P2 = (lt['P2'] | oo['P2']) - P3
+    P1 = oo['P1'] - (P2 | P3)
+    return {'P1': P1, 'P2': P2, 'P3': P3}
+
+
+def main_interval_logic(lt: dict[str, P.interval], oo: dict[str, P.interval], P0_has_priority=False) -> Table:
+    """Consider the following ordering of priorities: P3 > P2 > P1.
+    P0_has_priority determines if P0 is on the left or right of inequalities."""
+    if P0_has_priority:
+        for d in [lt, oo]:
+            for k in d.keys():
+                if k != 'P0':
+                    d[k] = d[k] - oo['P0']
+    lt['P2'] = lt['P2'] - lt['P3']
+    oo['P2'] = oo['P2'] - oo['P3']
+    oo['P1'] = oo['P1'] - (oo['P2'] | oo['P3'])
+    intervals = interval_merge_logic(lt, oo)
+    return pd.concat([interval_to_df(i).assign(status=f'{s} consistent') for s, i in intervals.items()])
+
+
+french_months = {1: 'janvier', 2: 'février', 3: 'mars', 4: 'avril', 5: 'mai', 6: 'juin',
+                 7: 'juillet', 8: 'août', 9: 'septembre', 10: 'octobre', 11: 'novembre', 12: 'décembre'}
+
+sar_text = """Bonjour,
+Je m'adresse à vous pour vous demander de directement relayer mon message auprès du Responsable de la Protection des Données d'Uber, Simon Hania, comme anticipé par le Règlement Général sur la Protection des Données européen. J'utilise pour ce faire un formulaire mis à disposition de ceux qui n'ont pas de compte Uber, mais qui me semble être ma meilleure chance de contacter directement Simon Hania, étant donnés donnés les multiples problèmes que vos services d'aide présentent.
+En effet, je conduis pour Uber et cherche à obtenir une copie de mes données personnelles. La page https://help.uber.com/fr-CA/driving-and-delivering/article/demander-vos-donn%C3%A9es-personnelles-uber?nodeId=fbf08e68-65ba-456b-9bc6-1369eb9d2c44 m'informe que mes données sont accessibles via le tableau de bord partenaire. Cependant, comme décrit à
+https://forum.personaldata.io/t/transparence-sur-les-donnees-personnelles-chez-uber/307
+la transparence offerte n'est pas suffisante à mon goût. Votre page d'information m'invite à contacter le Responsable dans ce cas, ce que je fais maintenant.
+Je cherche donc par la présente à exercer mes droits prévus par le RGPD. Ceci inclut mon droit d'accès (Art 15), mon droit à la portabilité (Art 20). Je vous rappelle que tout violation des dispositions concernant les droits des personnes (Art 12 à 22) peuvent faire l'objet - en vertu de l'Article 83 - d'amendes administratives pouvant s'élever jusqu'à 20 000 000 EUR ou, dans le cas d'une entreprise, jusqu'à 4 % du chiffre d'affaires annuel mondial total de l'exercice précédent, le montant le plus élevé étant retenu.
+
+Copie de mes données personnelles
+=================================
+Cette requête couvre toutes mes données personnelles, et en particulier celles concernant:
+- ma géolocalisation (y compris les empreintes temporelles associées, et les données d'accéléromètre);
+- mes revenus;
+- les interactions partenaires;
+- les interactions clients à mon propos, dont commentaires et notes;
+- les “expériences” que Uber a mis en place et dont j'étais sujet;
+- les contrats, chartes et règles d'utilisation pour lesquels j'ai marqué mon accord, sous leurs différentes versions, et dates associées;
+- les notifications par email ou "push" qui m'ont été envoyées, ainsi que mes interactions avec celles-ci;
+- les offres qui m'ont été envoyées, ainsi que mes interactions avec celles-ci;
+- toute cote de performance, délivrée par Uber ou des clients, jointement ou séparément;
+- mon téléphone (y compris: niveau de batterie, système d'exploitation, adresse IP, etc);
+- mon véhicule;
+- mon accueil comme partneraire Uber;
+- le dispatching et matching des courses pour lesquelles j'ai été retenu;
+- les courses que j'ai effectuées;
+- les tickets internes Zendesk du service partenaires me concernant moi ou mes courses;
+- les tickets internes Zendesk du service clients me concernant moi ou mes courses;
+- les "tags" des services clients et partenaires me concernant moi ou mes courses;
+- discussions internes à mon propos;
+- toute déconnection, temporaire ou permanente;
+- mes documents d'identité, d'assurances, de validation, etc, y compris ce qui en a été extrait automatiquement;
+- toute donnée de profilage;
+- la géolocalisation, les empreintes temporelles et les données d'accéléromètre du téléphone des clients lorsque nous nous trouvions simultanément dans mon véhicule.
+
+Concernant les données de géolocalisation, je voudrais obtenir l'entièreté de ces données détenues par Uber. Néanmoins mes confrères m'informent que Uber restreint artificiellement sa réponse et n'inclut que le mois le plus récent, pour une protéger les "rights and freedoms of others". Uber suggère alors de préciser des périodes additionnelles qu'elle évaluera alors. Dans le but d'accélérer ce processus, et tout en acceptant pas cette limitation artificielle de mes droits par Uber, je demande en particulier mes données de géolocalisation pour les périodes couvrant {REPLACE_HERE}.
+
+Je vous informe de l'existence de Guidelines de l'European Data Protection Board sur le Right of Access (https://edpb.europa.eu/system/files/2022-01/edpb_guidelines_012022_right-of-access_0.pdf ). Ces guidelines incluent différentes affirmations, telles que celles-ci: "Art. 15(4) GDPR should not result in a refusal to provide all information to the data subject.  This means, for example, where the limitation applies, that information concerning others has to be rendered illegible as far as possible instead of rejecting to provide a copy of the personal data." ou encore "he controller must be able to demonstrate that in the concrete situation rights or freedoms of others would factually be impacted." En conséquence Uber se doit de justifier son refus de rendre toutes les données de géolocalisation, et de proposer des méthodes alternatives.
+
+Article 20
+----------
+Pour les données tombant sous le coup du droit à la portabilité (RGPD Article 20), ce qui inclut toutes les données fournies par moi (Article 29 Working Party, *Guidelines on the Right to Data Portability (WP 242)*, 13 Décembre 2016, version française) et où la base juridique de traitement est le consentement ou le contrat, je souhaite:
+
+- **recevoir ces données dans un format structuré, couramment utilisé et lisible par machine**
+- accompagné avec un **description intelligible de toutes les variables**
+
+Article 15
+----------
+Pour les données tombant sous le coup du droit d'accès (RGPD Article 15), je voudrais **qu'une copie me soit envoyée dans un format électronique**. Veuillez noter que les données qui vous sont disponibles dans un format lisible par une machine doivent m'être fournies sous cette forme aussi, au vu des principes de loyauté (RGPD Article 5.1.a) et de protection des données dès la conception.
+
+Veuillez noter que toute opinion, déduction, préférence etc sont considérées comme des données personnelles (voir le Cas C‑434/16 *Peter Nowak v Data Protection Commissioner* [2017] ECLI:EU:C:2017:994, 34.)
+
+J'ai bien conscience que certaines des données que je demande concernent aussi des clients ou des employés de Uber. Je vous rappelle que dans ce cas il incombe à Uber de mettre en place des mesures pour protéger les droits de ces personnes, mais que cet argument ne peut être utilisé pour me refuser l'accès total à mes données. Pour des données de senseurs des appareils des clients lorsque ceux-ci se trouvent dans ma voiture par exemple, vous pourriez introduire un léger bruit dans les données pour masquer toute caractéristique individuelle de l'appareil.
+
+Si vous me considérez comme responsable du traitement
+-----------------------------------------------------
+De plus, si vous me considérez comme responsable du traitement de certaines de ces données et que vous agisseriez alors comme sous-traitant, veuillez me fournir alors toutes les donnéess que vous traitez en mon nom dans un format lisible par une machine, en accord avec votre obligation de respecter ma volonté sur les moyens et finalités du traitement.
+
+
+Métadonnées sur le traitement
+=============================
+
+Cette requête concerne aussi les métadonnées du traitement auxquelles j'ai droit suivant le RGPD.
+
+Information sur les responsables du traitement, sous-traitants, sources et transferts
+-------------------------------------------------------------------------------------
+Je voudrais de plus connaître
+- L'identité de tous les responsables conjoints du traitement, ainsi que grandes lignes de vos accords avec eux (RGPD Article 26).
+- Tout **destinataire à qui vous avez révélé des données**, nommées et avec leurs informations de contact en vertu de l'Article 15(1)(c). Veuillez noter que les régulateurs européens ont affirmé que par défaut les responsables de traitement doivent nommer les destinataires et pas les "catégories" de destinataires. Ils affirment de plus: "Si les responsables du traitement choisissent de communiquer les catégories de destinataires, les informations devraient être les plus spécifiques possible et indiquer le type de destinataire (en fonction des activités qu’il mène), l’industrie, le secteur et le sous-secteur ainsi que l’emplacement destinataires." (Article 29 Working Party, ‘Guidelines on Transparency under Regulation 2016/679’ WP260 rev.01, 11 April 2018 ) Ils affirment de plus que la notion de "destinataire" est plus large que celle de "tiers", et inclut "les autres responsables du traitement, responsables conjoints du traitement et sous-traitants auxquels les données sont transférées ou communiquée". L'article 4 paragraphe 9 définit de plus les destinataires comme incluant toute autorité publique. Veuillez noter de plus que pour toute donnée transférée sur base du consentement, on ne peut nommer simplement la catégorie sans invalider la base juridique (Article 29 Working Party, ‘Guidelines on Consent under Regulation 2016/679’ (WP259 rev.01, 10 April 2018) 13).
+- Si tout donnée n'a pas été collectée, observée ou déduite de moi directement, je voudrais de plus obtenir des informations précises sur la **source de cette donnée**, y compris le nom et l'adresse email de contact du responsable de traitement ("from which source the personal data originate", Article 14(2)(f)/15(1)(g)).
+- Veuilez de plus confirmer où mes données personnelles (y compris les backups) sont stockées, et au moins si elles ont quitté l'Union Européenne (et si oui, veuillez me fournir les détails des bases légales et protections pour de tels transferts).
+
+Information sur les finalités et les bases juridiques
+-----------------------------------------------------
+- Toutes les **finalités de traitement et les bases juridiques pour ces finalités par catégorie de donnée personnelle** Cette liste doit être fournie par finalité, base juridique détaillée par finalité, et catégorie de données détaillée par finalité et base juridique. Des listes séparées sans alignement entre ces trois facteurs ne seraient pas acceptables (Article 29 Working Party, ‘Guidelines on Transparency under Regulation 2016/679’ (WP260 rev.01, 11 April 2018), page 35.). Il se peut qu'une table soit la meilleure manière de fournir cette information.
+
+- Les intérêts légitimes détaillés là où cette base juridique est utilisée (Article 14(2)(b)).
+
+Information sur les prises de décision automatisées
+---------------------------------------------------
+- Veuillez confirmer si vous avez recours ou pas à des prises de décisions automatisées (au sens de l'Article 22, RGPD). Si la réponse est oui, veuillez fournir des informations utiles sur la logique sous-jacente, ainsi que l'importance et les conséquences prévues de ce traitement pour moi (Article 15(1)(h))
+
+Information sur la conservation
+-------------------------------
+- Veuillez me confirmer pendant combien de temps chaque catégorie de données est conservée, ainsi que les critères utilisés pour prendre cette décision, en accord avec le principe de limitation de la conservation, et l'Article 15(1)(d).
+
+Je me réjouis de recevoir très vite un accusé de réception, et une réponse plus complète endéans les 30 jours, comme anticipé par le RGPD."""


### PR DESCRIPTION
Many changes, including:
- pivoted tables around statuses so that now there is only one line per time period of interest (instead of many, each corresponding to a different status)
- integrated the ability to save the resulting tables in a single spreadsheet file https://github.com/hestiaAI/uber-analysis/pull/6
- moved most of the basic functionality to a new utils.py file
- defined a custom_types.py file
- can choose to see the most lucrative months of a driver. In that case, also generate a SAR request text with such months included

Breaking changes:
- due to pivoting, cannot process the data of some drivers for which the given statuses are inconsistent (one file says: status=A from t1 to t2, while another says status=B from the same t1 to the same t2). working on a fix